### PR TITLE
fix: image key default value 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,16 @@ venv/
 *.ntvs*
 *.njsproj
 *.sln
-*.sw?
+*.sw?^
+
+__pycache__/
+venv/
+*.pyc
+staticfiles
+static
+.DS_Store
+.idea
+.coverage
+.dccache
+.vscode/settings.json
+.vscode/tasks.json

--- a/backend/django-rest-auth/server/utils.py
+++ b/backend/django-rest-auth/server/utils.py
@@ -120,6 +120,9 @@ def calculate_result_list(data):
             underscores_str = replace_under_score(image_name)
             
             response_dict['Image'] = f''' https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/{underscores_str}&width=300'''
+        else:
+            response['Image'] = "No Image"
+
         result_list.append(response_dict)
     return result_list
 


### PR DESCRIPTION
"Image" key of the response data will have a default value of "No Image" if there's no image property of the WikiData.