### PR TITLE
MOBILE-351: Add Press Indicators to Navbar Buttons

### DIFF
--- a/mobile/searchitect/app/navbar.tsx
+++ b/mobile/searchitect/app/navbar.tsx
@@ -1,90 +1,107 @@
 import React, {useState} from 'react';
-import {Pressable, StyleSheet, Text, View, Image} from 'react-native';
-import {router} from 'expo-router';
+ import {Pressable, StyleSheet, Text, View, Image} from 'react-native';
+ import {router} from 'expo-router';
 
 
-const Navbar = () => {
-  return (
-    <View style={styles.navbar}>
-        <Pressable 
-          style={[styles.bordered, styles.circularButton, {left: "3%"}]}
-          onPress={() => {router.push("/home")}}
-          >
-            <Image
-                source={require('@/assets/images/home-icon.png')}
-                style={styles.buttonImage}
-            />
-        </Pressable>
-      <Pressable style={[styles.bordered, styles.rectangularButton, {left: "23%"}]}>
-        <Text style={styles.buttonText}>Quizzes</Text>
-      </Pressable>
-      <Pressable 
-        style={[styles.bordered, styles.rectangularButton, {right: "23%"}]}
-        >
-        <Text style={styles.buttonText}>Forums</Text>
-      </Pressable>
-      <Pressable style={[styles.bordered, styles.circularButton, {right: '3%'}]}>
-        <Image
-            source={require('@/assets/images/profile-icon.png')}
-            style={styles.buttonImage}
-            />
-      </Pressable>
-    </View>
-  );
-};
+ const Navbar = () => {
+   return (
+     <View style={styles.navbar}>
+         <Pressable 
+           style={({pressed}) => [
+            styles.bordered,
+            styles.circularButton, 
+            {left: "3%"},
+            {opacity: pressed ? 0.7 : 1}]}
+            onPress={() => {router.navigate('/home')}}
+           >
+             <Image
+                 source={require('@/assets/images/home-icon.png')}
+                 style={styles.buttonImage}
+             />
+         </Pressable>
+       <Pressable 
+          style={({pressed}) => [
+            styles.bordered,
+            styles.rectangularButton,
+            {left: "23%"},
+            {opacity: pressed ? 0.7 : 1}]}>
+         <Text style={styles.buttonText}>Quizzes</Text>
+       </Pressable>
+       <Pressable 
+         style={({pressed}) => [
+          styles.bordered,
+          styles.rectangularButton, 
+          {right: "23%"},
+          {opacity: pressed ? 0.7 : 1}]}
+         >
+         <Text style={styles.buttonText}>Forums</Text>
+       </Pressable>
+       <Pressable style={({pressed}) => [
+          styles.bordered, 
+          styles.circularButton,
+          {right: '3%'},
+          {opacity: pressed ? 0.7 : 1}]}>
+         <Image
+             source={require('@/assets/images/profile-icon.png')}
+             style={styles.buttonImage}
+             />
+       </Pressable>
+     </View>
+   );
+ };
 
-// TODO: Use percentage-based dimensions
-// TODO: Use a better font
-const styles = StyleSheet.create({
-  navbar: {
-    height: 60,
-    padding: 16,
-    borderBottomWidth: 2,
-    borderBottomColor: '#222',
-    backgroundColor: '#fff',  // Background color of the navbar
-    justifyContent: 'center',     // Center content vertically
-    alignItems: 'center',         // Center content horizontally
-    zIndex: 1,                    // Keep it on top of other elements
-  },
-  navText: {
-    color: '#000',               // Text color
-    fontSize: 18,
-    fontWeight: 'bold',
-  },
-  bordered: {
-    borderWidth: 3,
-    borderColor: "#222",
-  },
-  circularButton: {
-    position: 'absolute',
-    width: "15%",
-    aspectRatio: 1,
-    borderRadius: 100,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  rectangularButton: {
-    position: 'absolute',
-    backgroundColor: "#9775fa",
-    width: '30%',
-    height: '150%',
-    borderRadius: 10,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  buttonText: {
-    color: '#fff',
-    fontWeight: 'bold',
-    paddingHorizontal: 5,
-    paddingVertical: 2,
-    fontSize: 18,
-  },
-  buttonImage: {
-    position: 'absolute', // Position the image to cover the button
-    width: '90%',        // Full width of the button
-    height: '90%',
-  }
-})
+ // TODO: Use percentage-based dimensions
+ // TODO: Use a better font
+ const styles = StyleSheet.create({
+   navbar: {
+     height: 60,
+     padding: 16,
+     borderBottomWidth: 2,
+     borderBottomColor: '#222',
+     backgroundColor: '#fff',  // Background color of the navbar
+     justifyContent: 'center',     // Center content vertically
+     alignItems: 'center',         // Center content horizontally
+     zIndex: 1,                    // Keep it on top of other elements
+   },
+   navText: {
+     color: '#000',               // Text color
+     fontSize: 18,
+     fontWeight: 'bold',
+   },
+   bordered: {
+     borderWidth: 3,
+     borderColor: "#222",
+   },
+   circularButton: {
+     position: 'absolute',
+     width: "15%",
+     aspectRatio: 1,
+     borderRadius: 100,
+     justifyContent: 'center',
+     alignItems: 'center',
+   },
+   rectangularButton: {
+     position: 'absolute',
+     backgroundColor: "#9775fa",
+     width: '30%',
+     height: '150%',
+     borderRadius: 10,
+     justifyContent: 'center',
+     alignItems: 'center',
+   },
+   buttonText: {
+     color: '#fff',
+     fontWeight: 'bold',
+     paddingHorizontal: 5,
+     paddingVertical: 2,
+     fontSize: 18,
+   },
+   buttonImage: {
+     position: 'absolute', // Position the image to cover the button
+     width: '90%',        // Full width of the button
+     height: '90%',
+   }
+ })
 
 
-export default Navbar;
+ export default Navbar; 

--- a/mobile/searchitect/app/navbar.tsx
+++ b/mobile/searchitect/app/navbar.tsx
@@ -1,107 +1,114 @@
-import React, {useState} from 'react';
- import {Pressable, StyleSheet, Text, View, Image} from 'react-native';
- import {router} from 'expo-router';
+import React from "react";
+import { Pressable, StyleSheet, Text, View, Image } from "react-native";
+import { router } from "expo-router";
 
-
- const Navbar = () => {
-   return (
-     <View style={styles.navbar}>
-         <Pressable 
-           style={({pressed}) => [
-            styles.bordered,
-            styles.circularButton, 
-            {left: "3%"},
-            {opacity: pressed ? 0.7 : 1}]}
-            onPress={() => {router.navigate('/home')}}
-           >
-             <Image
-                 source={require('@/assets/images/home-icon.png')}
-                 style={styles.buttonImage}
-             />
-         </Pressable>
-       <Pressable 
-          style={({pressed}) => [
-            styles.bordered,
-            styles.rectangularButton,
-            {left: "23%"},
-            {opacity: pressed ? 0.7 : 1}]}>
-         <Text style={styles.buttonText}>Quizzes</Text>
-       </Pressable>
-       <Pressable 
-         style={({pressed}) => [
+const Navbar = () => {
+  return (
+    <View style={styles.navbar}>
+      <Pressable
+        style={({ pressed }) => [
           styles.bordered,
-          styles.rectangularButton, 
-          {right: "23%"},
-          {opacity: pressed ? 0.7 : 1}]}
-         >
-         <Text style={styles.buttonText}>Forums</Text>
-       </Pressable>
-       <Pressable style={({pressed}) => [
-          styles.bordered, 
           styles.circularButton,
-          {right: '3%'},
-          {opacity: pressed ? 0.7 : 1}]}>
-         <Image
-             source={require('@/assets/images/profile-icon.png')}
-             style={styles.buttonImage}
-             />
-       </Pressable>
-     </View>
-   );
- };
+          { left: "3%" },
+          { opacity: pressed ? 0.7 : 1 },
+        ]}
+        onPress={() => {
+          router.navigate("/home");
+        }}
+      >
+        <Image
+          source={require("@/assets/images/home-icon.png")}
+          style={styles.buttonImage}
+        />
+      </Pressable>
+      <Pressable
+        style={({ pressed }) => [
+          styles.bordered,
+          styles.rectangularButton,
+          { left: "23%" },
+          { opacity: pressed ? 0.7 : 1 },
+        ]}
+      >
+        <Text style={styles.buttonText}>Quizzes</Text>
+      </Pressable>
+      <Pressable
+        style={({ pressed }) => [
+          styles.bordered,
+          styles.rectangularButton,
+          { right: "23%" },
+          { opacity: pressed ? 0.7 : 1 },
+        ]}
+      >
+        <Text style={styles.buttonText}>Forums</Text>
+      </Pressable>
+      <Pressable
+        style={({ pressed }) => [
+          styles.bordered,
+          styles.circularButton,
+          { right: "3%" },
+          { opacity: pressed ? 0.7 : 1 },
+        ]}
+      >
+        <Image
+          source={require("@/assets/images/profile-icon.png")}
+          style={styles.buttonImage}
+        />
+      </Pressable>
+    </View>
+  );
+};
 
- // TODO: Use percentage-based dimensions
- // TODO: Use a better font
- const styles = StyleSheet.create({
-   navbar: {
-     height: 60,
-     padding: 16,
-     borderBottomWidth: 2,
-     borderBottomColor: '#222',
-     backgroundColor: '#fff',  // Background color of the navbar
-     justifyContent: 'center',     // Center content vertically
-     alignItems: 'center',         // Center content horizontally
-     zIndex: 1,                    // Keep it on top of other elements
-   },
-   navText: {
-     color: '#000',               // Text color
-     fontSize: 18,
-     fontWeight: 'bold',
-   },
-   bordered: {
-     borderWidth: 3,
-     borderColor: "#222",
-   },
-   circularButton: {
-     position: 'absolute',
-     width: "15%",
-     aspectRatio: 1,
-     borderRadius: 100,
-     justifyContent: 'center',
-     alignItems: 'center',
-   },
-   rectangularButton: {
-     position: 'absolute',
-     backgroundColor: "#9775fa",
-     width: '30%',
-     height: '150%',
-     borderRadius: 10,
-     justifyContent: 'center',
-     alignItems: 'center',
-   },
-   buttonText: {
-     color: '#fff',
-     fontWeight: 'bold',
-     paddingHorizontal: 5,
-     paddingVertical: 2,
-     fontSize: 18,
-   },
-   buttonImage: {
-     position: 'absolute', // Position the image to cover the button
-     width: '90%',        // Full width of the button
-     height: '90%',
-   }
- })
+// TODO: Use percentage-based dimensions
+// TODO: Use a better font
+const styles = StyleSheet.create({
+  navbar: {
+    height: 60,
+    padding: 16,
+    borderBottomWidth: 2,
+    borderBottomColor: "#222",
+    backgroundColor: "#fff", // Background color of the navbar
+    justifyContent: "center", // Center content vertically
+    alignItems: "center", // Center content horizontally
+    zIndex: 1, // Keep it on top of other elements
+  },
+  navText: {
+    color: "#000", // Text color
+    fontSize: 18,
+    fontWeight: "bold",
+  },
+  bordered: {
+    borderWidth: 3,
+    borderColor: "#222",
+  },
+  circularButton: {
+    position: "absolute",
+    width: "15%",
+    aspectRatio: 1,
+    borderRadius: 100,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  rectangularButton: {
+    position: "absolute",
+    backgroundColor: "#9775fa",
+    width: "30%",
+    height: "150%",
+    borderRadius: 10,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  buttonText: {
+    color: "#fff",
+    fontWeight: "bold",
+    paddingHorizontal: 5,
+    paddingVertical: 2,
+    fontSize: 18,
+  },
+  buttonImage: {
+    position: "absolute", // Position the image to cover the button
+    width: "90%",
+    height: "90%",
+  },
+});
 
-
- export default Navbar; 
+export default Navbar;


### PR DESCRIPTION
Fixes #351.

In this implementation, the buttons in the Navbar have their opacity reduced to 70% when they are pressed. We could indicate the button presses some other way if you have any other ideas (such as by changing the background color).

Also, the navbar.tsx file has been formatted for better readability, using the tool "https://codebeautify.org/react-formatter".