### PR TITLE
feat(mobile): add extensible navbar buttons

### DIFF
--- a/mobile/searchitect/app/navbar.tsx
+++ b/mobile/searchitect/app/navbar.tsx
@@ -7,6 +7,10 @@ type NavbarProps = {
   quizOnPress?: () => void,
   forumOnPress?: () => void,
   profileOnPress?: () => void,
+  homeOnPressOverride?: () => void,
+  quizOnPressOverride?: () => void,
+  forumOnPressOverride?: () => void,
+  profileOnPressOverride?: () => void,
 }
 
 const Navbar = (props: NavbarProps) => {
@@ -20,10 +24,15 @@ const Navbar = (props: NavbarProps) => {
           { opacity: pressed ? 0.7 : 1 },
         ]}
         onPress={() => {
-          if (props.homeOnPress) {
-            props.homeOnPress();
-          };
-          router.navigate("/home");
+          if (props.homeOnPressOverride){
+            props.homeOnPressOverride();
+          }
+          else {
+            if (props.homeOnPress) {
+              props.homeOnPress();
+            };
+            router.navigate("/home");
+          }
         }}
       >
         <Image
@@ -39,9 +48,14 @@ const Navbar = (props: NavbarProps) => {
           { opacity: pressed ? 0.7 : 1 },
         ]}
         onPress = {() => {
-          if (props.quizOnPress) {
-            props.quizOnPress();
-          };
+          if (props.quizOnPressOverride){
+            props.quizOnPressOverride();
+          }
+          else {
+            if (props.quizOnPress) {
+              props.quizOnPress();
+            };
+          }
         }}
       >
         <Text style={styles.buttonText}>Quizzes</Text>
@@ -54,9 +68,14 @@ const Navbar = (props: NavbarProps) => {
           { opacity: pressed ? 0.7 : 1 },
         ]}
         onPress = {() => {
-          if (props.forumOnPress) {
-            props.forumOnPress();
-          };
+          if (props.forumOnPressOverride){
+            props.forumOnPressOverride();
+          }
+          else {
+            if (props.forumOnPress) {
+              props.forumOnPress();
+            };
+          }
         }}
       >
         <Text style={styles.buttonText}>Forums</Text>
@@ -69,9 +88,14 @@ const Navbar = (props: NavbarProps) => {
           { opacity: pressed ? 0.7 : 1 },
         ]}
         onPress = {() => {
-          if (props.forumOnPress) {
-            props.forumOnPress();
-          };
+          if (props.profileOnPressOverride){
+            props.profileOnPressOverride();
+          }
+          else {
+            if (props.profileOnPress) {
+              props.profileOnPress();
+            };
+          }
         }}
       >
         <Image

--- a/mobile/searchitect/app/navbar.tsx
+++ b/mobile/searchitect/app/navbar.tsx
@@ -2,7 +2,14 @@ import React from "react";
 import { Pressable, StyleSheet, Text, View, Image } from "react-native";
 import { router } from "expo-router";
 
-const Navbar = () => {
+type NavbarProps = {
+  homeOnPress?: () => void,
+  quizOnPress?: () => void,
+  forumOnPress?: () => void,
+  profileOnPress?: () => void,
+}
+
+const Navbar = (props: NavbarProps) => {
   return (
     <View style={styles.navbar}>
       <Pressable
@@ -13,6 +20,9 @@ const Navbar = () => {
           { opacity: pressed ? 0.7 : 1 },
         ]}
         onPress={() => {
+          if (props.homeOnPress) {
+            props.homeOnPress();
+          };
           router.navigate("/home");
         }}
       >
@@ -28,6 +38,11 @@ const Navbar = () => {
           { left: "23%" },
           { opacity: pressed ? 0.7 : 1 },
         ]}
+        onPress = {() => {
+          if (props.quizOnPress) {
+            props.quizOnPress();
+          };
+        }}
       >
         <Text style={styles.buttonText}>Quizzes</Text>
       </Pressable>
@@ -38,6 +53,11 @@ const Navbar = () => {
           { right: "23%" },
           { opacity: pressed ? 0.7 : 1 },
         ]}
+        onPress = {() => {
+          if (props.forumOnPress) {
+            props.forumOnPress();
+          };
+        }}
       >
         <Text style={styles.buttonText}>Forums</Text>
       </Pressable>
@@ -48,6 +68,11 @@ const Navbar = () => {
           { right: "3%" },
           { opacity: pressed ? 0.7 : 1 },
         ]}
+        onPress = {() => {
+          if (props.forumOnPress) {
+            props.forumOnPress();
+          };
+        }}
       >
         <Image
           source={require("@/assets/images/profile-icon.png")}


### PR DESCRIPTION
This PR includes a small functional change to the Navbar component. It can be used in the same way as before, but now it also takes 4 optional arguments for the 4 buttons it has to enable extending its functionality. These optional functions are called before the Navbar performs its normal onPress functionality.