### PR TITLE
refactor(mobile): redesign login and register pages 

### DIFF
--- a/mobile/bulingo/app/login.tsx
+++ b/mobile/bulingo/app/login.tsx
@@ -71,12 +71,13 @@ export default function Home() {
 
       <View style={styles.navbarContainer}><Navbar/></View>
         <View style={styles.page}>
+        
 
+
+          <View style={[styles.loginContainer, styles.elevation]}>
           <View style={styles.titleContainer}>
             <Text style={styles.titleText}>Log In</Text>
           </View>
-
-          <View style={styles.loginContainer}>
             <View style={styles.namedUserInput}>
               <Text style={styles.userInputText}>E-mail:</Text>
               <View style={styles.inputBox}>
@@ -107,8 +108,6 @@ export default function Home() {
                 <Text style={styles.buttonText}>Log In</Text>
               </Pressable>
             </View>
-          </View>
-          <View style={styles.registerContainer} >
             <Text style={styles.smallText}>Don't have an account?</Text>
             <View style={styles.buttonContainer}>
               <Pressable style={[styles.rectangularButton, {backgroundColor: 'gray'}]} onPress={handleRegister} disabled={true}>
@@ -129,11 +128,15 @@ const styles = StyleSheet.create({
     marginTop: 30,
     backgroundColor: '#fff'
   },
+  elevation: {
+    elevation: 30,
+    shadowColor: 'black',
+  },
   navbarContainer: {
     flex: 1,
   },
   page: {
-    flex: 7,
+    flex: 9,
     justifyContent: "space-around",
     alignItems: 'stretch',
     backgroundColor: '#fff'
@@ -144,20 +147,16 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   loginContainer: {
-    flex: 2,
+    flex: 0.6,
     justifyContent: 'center',
+    backgroundColor: 'white',
+    alignContent: 'center',
   },
-  registerContainer: {
-    flex: 1,
-    justifyContent: 'flex-end',
-    alignItems: 'stretch',
-    marginBottom: 30,
-  },
+
   namedUserInput: {
     flex: 1,
     marginLeft: 40,
     marginRight: 40,
-    alignItems: 'stretch',
   },
   buttonContainer: {
     flex: 1,
@@ -166,27 +165,24 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   titleText: {
-    flex: 1,
     textAlign: 'center',
     fontSize: 30,
   },
   userInputText: {
     fontSize: 16,
-    margin: 5,
     textAlign: 'left',
   },
   inputBox: {
     justifyContent: 'center',
-    backgroundColor: "#ffec99",
+    backgroundColor: "#E8E8E8",
     height: 50,
     borderRadius: 10,
-    borderWidth: 3,
-    borderColor: "#222",
   },
   input: {
-    flex: 1,
-    margin: 5,
+    backgroundColor: '#E8E8E8',
+    borderRadius: 10,
     fontSize: 16,
+    marginLeft: 10,
   },
   smallText:{
     fontSize: 12,
@@ -194,15 +190,12 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   rectangularButton: {
-    backgroundColor: "#9775fa",
+    backgroundColor: "#3944FD",
     width: '80%',
     height: 50,
     borderRadius: 10,
     justifyContent: 'center',
     alignItems: 'center',
-    margin: 5,
-    borderWidth: 3,
-    borderColor: "#222",
   },
   buttonText: {
     color: '#fff',

--- a/mobile/bulingo/app/login.tsx
+++ b/mobile/bulingo/app/login.tsx
@@ -100,7 +100,7 @@ export default function Home() {
                 </TextInput>
               </View>
             </View>
-            <View style={styles.buttonContainer}>
+            <View style={[styles.buttonContainer, {marginTop:10}]}>
                 {isErrorVisible && (
                   <Text style={styles.errorMessage}>Wrong Login information</Text>
                 )}

--- a/mobile/bulingo/app/login.tsx
+++ b/mobile/bulingo/app/login.tsx
@@ -74,7 +74,6 @@ export default function Home() {
         
 
 
-          <View style={[styles.loginContainer, styles.elevation]}>
           <View style={styles.titleContainer}>
             <Text style={styles.titleText}>Log In</Text>
           </View>
@@ -114,7 +113,6 @@ export default function Home() {
                 <Text style={styles.buttonText}>Register</Text>
               </Pressable>
             </View>
-          </View>
         </View>
     </View>
   );

--- a/mobile/bulingo/app/register.tsx
+++ b/mobile/bulingo/app/register.tsx
@@ -184,6 +184,7 @@ const Register = () => {
 
       
       <Text style={styles.label}>Level:</Text>
+      <View style={{borderRadius: 10, overflow: 'hidden', marginBottom: 16}}>
       <Picker
         selectedValue={level}
         style={styles.picker}
@@ -196,6 +197,7 @@ const Register = () => {
         <Picker.Item label="C1" value="C1" />
         <Picker.Item label="C2" value="C2" />
       </Picker>
+      </View>
 
       <TouchableOpacity 
         style={[styles.button, (!isFormValid || isTyping) ? styles.buttonDisabled : null]} // Disable styling
@@ -227,7 +229,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: 20,
     textAlign: 'center',
-    color: '#800080',
+    color: '#3944FD',
   },
   label: {
     fontSize: 18,
@@ -235,17 +237,18 @@ const styles = StyleSheet.create({
     color: '#333',
   },
   input: {
-    backgroundColor: '#ffec99',
-    padding: 10,
-    borderRadius: 8,
-    fontSize: 16,
-    marginBottom: 0,
+    minHeight : 30,
+    backgroundColor: '#E8E8E8',
+    borderRadius: 10,
+    flex: 0.14,
+    marginRight: 10,
+    paddingLeft: 10,
   },
   picker: {
-    height: 50,
-    backgroundColor: '#FFEB3B',
-    borderRadius: 8,
-    marginBottom: 16,
+
+    height : 50,
+    backgroundColor: '#E8E8E8',
+    borderRadius: 10,
   },
   registerButton: {
     backgroundColor: '#800080',
@@ -284,7 +287,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
   button: {
-    backgroundColor: '#9775fa',
+    backgroundColor: '#3944FD',
     paddingVertical: 10,
     borderRadius: 5,
   },
@@ -292,9 +295,10 @@ const styles = StyleSheet.create({
     backgroundColor: '#A9A9A9', // Gray color when disabled
   },
   buttonText: {
-    color: '#fff',
+    color: 'white',
     textAlign: 'center',
-    fontSize: 16,
+    fontSize: 18,
+    fontWeight: 'bold',
   },
 });
 


### PR DESCRIPTION
Fixes #463.

- Login page is redesigned. 
<img width="349" alt="Screenshot 2024-11-05 at 11 42 48" src="https://github.com/user-attachments/assets/a4e3d841-f708-4268-b7ef-4ef87a4dc3e9">

- Register page is redesigned. 

<img width="349" alt="Screenshot 2024-11-05 at 11 43 28" src="https://github.com/user-attachments/assets/dc911542-b9a6-4b89-b208-63bd3321849e">


- Home page is moved to the new tabs section.