### PR TITLE
feat(mobile): Search Page

### DIFF
--- a/mobile/bulingo/app/(tabs)/_layout.tsx
+++ b/mobile/bulingo/app/(tabs)/_layout.tsx
@@ -2,11 +2,12 @@ import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { Tabs } from 'expo-router';
 import React, {useState} from 'react';
 import {TouchableOpacity} from 'react-native';
+import { RFPercentage } from 'react-native-responsive-fontsize';
 
 export default function TabLayout() {
   return (
     <>
-      <Tabs screenOptions={{ tabBarActiveTintColor: 'red', headerShown: false, tabBarStyle:{paddingBottom:5, paddingTop: 5}}}>
+      <Tabs screenOptions={{ tabBarActiveTintColor: 'red', headerShown: false, tabBarLabelStyle:{fontSize: RFPercentage(1.5)}}}>
         <Tabs.Screen
           name="index"
           options={{

--- a/mobile/bulingo/app/(tabs)/_layout.tsx
+++ b/mobile/bulingo/app/(tabs)/_layout.tsx
@@ -25,6 +25,7 @@ export default function TabLayout() {
         <Tabs.Screen
           name="search"
           options={{
+            headerShown: true,
             title: 'Search',
             tabBarIcon: ({ color }) => <FontAwesome size={28} name="search" color={color} />,
           }}

--- a/mobile/bulingo/app/(tabs)/_layout.tsx
+++ b/mobile/bulingo/app/(tabs)/_layout.tsx
@@ -1,13 +1,11 @@
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { Tabs } from 'expo-router';
-import React, {useState} from 'react';
-import {TouchableOpacity} from 'react-native';
-import { RFPercentage } from 'react-native-responsive-fontsize';
+import React from 'react';
 
 export default function TabLayout() {
   return (
     <>
-      <Tabs screenOptions={{ tabBarActiveTintColor: 'red', headerShown: false, tabBarLabelStyle:{fontSize: RFPercentage(1.5)}}}>
+      <Tabs screenOptions={{ tabBarActiveTintColor: 'red', headerShown: false}}>
         <Tabs.Screen
           name="index"
           options={{

--- a/mobile/bulingo/app/(tabs)/profile/userCard.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/userCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TouchableOpacity, View, Image, StyleSheet, Text } from 'react-native';
 import { RFPercentage } from 'react-native-responsive-fontsize';
-import { router } from 'expo-router';
+import { router, useSegments } from 'expo-router';
 
 type UserCardProps = {
   profilePictureUri: string,
@@ -15,6 +15,7 @@ type UserCardProps = {
 };
 
 const UserCard = (props: UserCardProps) => {
+  const segments = useSegments();
   const handleButtonPress = () => {
     console.log("Button Pressed: " + props.username);
     if (props.onButtonPress){
@@ -26,7 +27,11 @@ const UserCard = (props: UserCardProps) => {
     if (props.onCardPress){ 
       props.onCardPress();
     }
-    router.push(`/(tabs)/profile/users/${props.username}`)
+
+    router.navigate('/(tabs)/profile')
+    setTimeout(() => {
+      router.push(`/(tabs)/profile/users/${props.username}`);
+    }, 0);
   };
 
   let buttonStyleAddOn;

--- a/mobile/bulingo/app/(tabs)/profile/userCard.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/userCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TouchableOpacity, View, Image, StyleSheet, Text } from 'react-native';
 import { RFPercentage } from 'react-native-responsive-fontsize';
-import { router, useSegments } from 'expo-router';
+import { router } from 'expo-router';
 
 type UserCardProps = {
   profilePictureUri: string,
@@ -15,7 +15,6 @@ type UserCardProps = {
 };
 
 const UserCard = (props: UserCardProps) => {
-  const segments = useSegments();
   const handleButtonPress = () => {
     console.log("Button Pressed: " + props.username);
     if (props.onButtonPress){

--- a/mobile/bulingo/app/(tabs)/search.tsx
+++ b/mobile/bulingo/app/(tabs)/search.tsx
@@ -349,11 +349,11 @@ const styles = StyleSheet.create({
   tagBox: {
     height: RFPercentage(3.5),
     borderRadius: RFPercentage(1.5),
-    width: RFPercentage(14),
-    borderWidth: RFPercentage(0.2),
+    borderWidth: 2,
     borderColor: 'gray',
     justifyContent: 'center',
-    margin: 5,
+    marginVertical: 5,
+    width: '30%',
   },
   tagBoxActive: {
     borderColor: 'blue',

--- a/mobile/bulingo/app/(tabs)/search.tsx
+++ b/mobile/bulingo/app/(tabs)/search.tsx
@@ -8,6 +8,8 @@ const CONTENT_TYPES = ["Users", "Quizzes", "Posts", "Comments"]
 
 export default function Tab() {
   const [searchResults, setSearchResults] = useState<any>(undefined);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [userInput, setUserInput] = useState("");
   const [sortByOption, setSortByOption] = useState<string>('Sort by');
   const [contentTypesOption, setContentTypesOption] = useState<{name: string, active: boolean}[]>(
     CONTENT_TYPES.map(ct => ({name: ct, active: true}))
@@ -20,13 +22,23 @@ export default function Tab() {
   const [tagsModalOpen, setTagsModalOpen] = useState(false);
 
 
+  // Temporary, will be changed when connection with backend is made.
+  useEffect(() => {
+    const fetchResults = async (params: any) => {
+      console.log("fetchResults called, returning mock data")
+      setSearchResults([]);
+    };
+    fetchResults({});
+  }, [sortByOption, contentTypesOption, tagsOption, searchQuery]);
+
+
   return (
     <View style={styles.container}>
       <View style={styles.topContainer}>
         <View style={styles.searchBar}>
           <View style={styles.searchBox}>
-            <TextInput style={styles.searchText} placeholder='Search'/>
-            <TouchableOpacity onPress={() => console.log(contentTypesOption)}>
+            <TextInput style={styles.searchText} placeholder='Search' onChangeText={setUserInput} onEndEditing={() => setSearchQuery(userInput)}/>
+            <TouchableOpacity onPress={() => setSearchQuery(userInput)}>
               <FontAwesome name="search" style={styles.searchButton}/>
             </TouchableOpacity>
           </View>
@@ -43,7 +55,7 @@ export default function Tab() {
           </TouchableOpacity>
         </View>
       </View>
-      {searchResults === undefined ? 
+      {searchResults.length == 0 ? 
         <View style={styles.reminderContainer}>
           <FontAwesome name='search' style={styles.reminderIcon}/>
           <Text style={styles.reminderText}>Use the search bar above to search for quizzes, forums and users!</Text>
@@ -127,7 +139,7 @@ const MultiChoiceModalType2 = (props: MultiChoiceModalProps) => {
 
   useEffect(() => {
     chunkedOptions = chunkArray(tempOptions, 3);
-  }, [tempOptions]); // Dependency array
+  }, [tempOptions]);
   
 
   return (

--- a/mobile/bulingo/app/(tabs)/search.tsx
+++ b/mobile/bulingo/app/(tabs)/search.tsx
@@ -144,7 +144,7 @@ const SimpleModal = (props: SimpleModalProps) => {
       <View style={styles.modalContent}>
         {props.options.map((item, index) => (
           <TouchableOpacity key={index} style={styles.simpleModalItem} onPress={() => {props.setModalOpen(false); props.setOption(item == 'Clear' ? 'Sort by' : item)}}>
-              <Text style={styles.simpleModalText}>{item}</Text>
+              <Text style={[styles.simpleModalText, item == 'Clear' && {color: 'red'}]}>{item}</Text>
           </TouchableOpacity>
         ))}
       </View>

--- a/mobile/bulingo/app/(tabs)/search.tsx
+++ b/mobile/bulingo/app/(tabs)/search.tsx
@@ -114,7 +114,7 @@ export default function Tab() {
       </View>
       {renderSearchResults()}
       {sortByModalOpen && 
-        <SimpleModal options={["Newest", "Most Liked"]} setOption={setSortByOption} setModalOpen={setSortByModalOpen}/>
+        <SimpleModal options={["Newest", "Most Liked", "Clear"]} setOption={setSortByOption} setModalOpen={setSortByModalOpen}/>
       }
       {contentTypeModalOpen && 
         <MultiChoiceModal options={contentTypesOption} setOptions={setContentTypesOption} setModalOpen={setContentTypeModalOpen}/>
@@ -143,7 +143,7 @@ const SimpleModal = (props: SimpleModalProps) => {
     <Pressable style={styles.modalOverlay} onPress={() => {props.setModalOpen(false)}}>
       <View style={styles.modalContent}>
         {props.options.map((item, index) => (
-          <TouchableOpacity key={index} style={styles.simpleModalItem} onPress={() => {props.setModalOpen(false); props.setOption(item)}}>
+          <TouchableOpacity key={index} style={styles.simpleModalItem} onPress={() => {props.setModalOpen(false); props.setOption(item == 'Clear' ? 'Sort by' : item)}}>
               <Text style={styles.simpleModalText}>{item}</Text>
           </TouchableOpacity>
         ))}

--- a/mobile/bulingo/app/(tabs)/search.tsx
+++ b/mobile/bulingo/app/(tabs)/search.tsx
@@ -1,17 +1,306 @@
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import { View, TextInput, StyleSheet, TouchableOpacity, Text, Pressable } from 'react-native';
+import { RFPercentage } from 'react-native-responsive-fontsize';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+
+const TAGS = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2', 'TAG1', 'TAG2', 'TAG3', 'GRAMMAR'];
+const CONTENT_TYPES = ["Users", "Quizzes", "Posts", "Comments"]
 
 export default function Tab() {
+  const [searchResults, setSearchResults] = useState<any>(undefined);
+  const [sortByOption, setSortByOption] = useState<string>('Sort by');
+  const [contentTypesOption, setContentTypesOption] = useState<{name: string, active: boolean}[]>(
+    CONTENT_TYPES.map(ct => ({name: ct, active: true}))
+  );
+  const [tagsOption, setTagsOptions] = useState<{name: string, active: boolean}[]>(
+    TAGS.map(tag => ({name: tag, active:true}))
+  );
+  const [sortByModalOpen, setSortByModalOpen] = useState(false);
+  const [contentTypeModalOpen, setContentTypeModalOpen] = useState(false);
+  const [tagsModalOpen, setTagsModalOpen] = useState(false);
+
+
   return (
     <View style={styles.container}>
-      <Text>Search</Text>
+      <View style={styles.topContainer}>
+        <View style={styles.searchBar}>
+          <View style={styles.searchBox}>
+            <TextInput style={styles.searchText} placeholder='Search'/>
+            <TouchableOpacity onPress={() => console.log(contentTypesOption)}>
+              <FontAwesome name="search" style={styles.searchButton}/>
+            </TouchableOpacity>
+          </View>
+        </View>
+        <View style={styles.optionsBar}>
+          <TouchableOpacity style={styles.optionBox} onPress={() => setSortByModalOpen(true)}>
+            <Text style={sortByOption == 'Sort by' ? styles.passiveOptionText : styles.activeOptionText}>{sortByOption}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.optionBox} onPress={() => setContentTypeModalOpen(true)}>
+            <Text style={styles.passiveOptionText}>Content</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.optionBox} onPress={() => setTagsModalOpen(true)}>
+            <Text style={styles.passiveOptionText}>Tags</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+      {searchResults === undefined ? 
+        <View style={styles.reminderContainer}>
+          <FontAwesome name='search' style={styles.reminderIcon}/>
+          <Text style={styles.reminderText}>Use the search bar above to search for quizzes, forums and users!</Text>
+        </View> :
+        <Text>Yay</Text>
+      }
+      {sortByModalOpen && 
+        <SimpleModal options={["Newest", "Most Liked"]} setOption={setSortByOption} setModalOpen={setSortByModalOpen}/>
+      }
+      {contentTypeModalOpen && 
+        <MultiChoiceModal options={contentTypesOption} setOptions={setContentTypesOption} setModalOpen={setContentTypeModalOpen}/>
+      }
+      {tagsModalOpen && 
+        <MultiChoiceModalType2 options={tagsOption} setOptions={setTagsOptions} setModalOpen={setTagsModalOpen}/>
+      }
     </View>
   );
 }
 
+type SimpleModalProps = {
+  options: string[],
+  setOption: (option: string) => void;
+  setModalOpen: (arg0: boolean) => void;
+};
+
+const SimpleModal = (props: SimpleModalProps) => {
+  return (
+    <Pressable style={styles.modalOverlay} onPress={() => {props.setModalOpen(false)}}>
+      <View style={styles.modalContent}>
+        {props.options.map((item, index) => (
+          <TouchableOpacity key={index} style={styles.simpleModalItem} onPress={() => {props.setModalOpen(false); props.setOption(item)}}>
+              <Text style={styles.simpleModalText}>{item}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </Pressable>
+  );
+};
+
+type MultiChoiceModalProps = {
+  options: {active: boolean, name: string}[],
+  setOptions: (options: {active: boolean, name: string}[]) => void;
+  setModalOpen: (arg0: boolean) => void;
+};
+
+const MultiChoiceModal = (props: MultiChoiceModalProps) => {
+  const [tempOptions, setTempOptions] = useState(props.options);
+
+  return (
+    <Pressable style={styles.modalOverlay} onPress={() => {props.setModalOpen(false); props.setOptions(tempOptions)}}>
+      <View style={styles.modalContent}>
+        {tempOptions.map((item, index) => (
+          <Pressable key={index} style={styles.multiChoiceModalItem} >
+              <TouchableOpacity 
+                style={[styles.checkbox, item.active && styles.checkboxActiveAddOn]}
+                onPress={() => {
+                  setTempOptions(
+                    tempOptions.map(
+                      (it, idx) => (idx === index ? {name: it.name, active: !it.active} : it)))}}
+                />
+              <Text style={styles.simpleModalText}>{item.name}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </Pressable>
+  );
+};
+
+// Helper function to chunk the array
+const chunkArray = (array: any[], size: number) => {
+  const chunks = [];
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size));
+  }
+  return chunks;
+};
+
+const MultiChoiceModalType2 = (props: MultiChoiceModalProps) => {
+  const [tempOptions, setTempOptions] = useState(props.options);
+  let chunkedOptions = chunkArray(tempOptions, 3);
+
+  useEffect(() => {
+    chunkedOptions = chunkArray(tempOptions, 3);
+  }, [tempOptions]); // Dependency array
+  
+
+  return (
+    <Pressable style={styles.modalOverlay} onPress={() => {props.setModalOpen(false); props.setOptions(tempOptions)}}>
+      <View style={styles.modalContent}>
+        {chunkedOptions.map((row, rowIndex) => (
+          <View key={rowIndex} style={styles.tagModalRow}>
+            {row.map((item, colIndex) => (
+              <TouchableOpacity
+              key={colIndex} 
+                style={[styles.tagBox, item.active && styles.tagBoxActive]}
+                onPress={() => {
+                  setTempOptions(
+                    tempOptions.map(
+                      (it, idx) => (it == item ? {name: it.name, active: !it.active} : it)))}}
+                >
+                <Text style={[styles.tagText, item.active && styles.tagTextActive]}>{item.name}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        ))}
+      </View>
+    </Pressable>
+  );
+};
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    justifyContent: 'flex-start',
+    alignItems: 'stretch',
+  },
+  topContainer: {
+    flex: 0,
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    padding: 10,
+  },
+  searchBar: {
+    flex: 0,
+    padding: 10,
+    justifyContent: 'center',
+    alignItems: 'stretch',
+  },
+  searchBox: {
+    borderRadius: 10,
+    backgroundColor: 'white',
+    elevation: 2,
+    flexDirection: 'row',
+    height: RFPercentage(6),
+    padding: 10,
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  searchText: {
+    fontSize: RFPercentage(2.2),
+    width: '90%',
+  },
+  searchButton: {
+    fontSize: RFPercentage(2.8),
+  },
+  optionsBar: {
+    flex: 0,
+    justifyContent: 'space-around',
+    alignItems: 'center',
+    flexDirection: 'row',
+    padding: 4,
+  },
+  optionBox: {
+    borderRadius: 10,
+    backgroundColor: 'white',
+    elevation: 2,
+    flex: 1,
+    height: RFPercentage(5.5),
+    marginHorizontal: 8,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  reminderContainer: {
+    flex: 1,
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    padding: 20,
+  },
+  reminderIcon: {
+    color: 'gray',
+    fontSize: RFPercentage(20),
+    margin: 20,
+  },
+  reminderText: {
+    fontSize: RFPercentage(1.9),
+    textAlign: 'center',
+    width: '70%',
+  },
+  passiveOptionText: {
+    fontSize: RFPercentage(2),
+  },
+  activeOptionText: {
+    color: 'blue',
+    fontSize: RFPercentage(2),
+    fontWeight: 'bold',
+  },
+  modalOverlay: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'stretch',
+  },
+  modalContent: {
+    flex: 0,
+    justifyContent:'center',
+    alignItems: 'stretch',
+    padding: 10,
+    backgroundColor: 'white',
+    borderRadius: 10,
+    margin: 15,
+  },
+  simpleModalItem: {
+    height: RFPercentage(7),
+    justifyContent: 'center',
+    margin: 3,
+  },
+  multiChoiceModalItem: {
+    height: RFPercentage(5),
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    flexDirection: 'row',
+  },
+  checkbox: {
+    borderWidth: 1,
+    borderColor: 'black',
+    backgroundColor: 'white',
+    elevation: 2,
+    height: 20,
+    width: 20,
+    borderRadius: 5,
+    marginRight: 10,
+    marginTop: 2,
+  },
+  checkboxActiveAddOn: {
+    backgroundColor: 'blue',
+  },
+  simpleModalText: {
+    fontSize: RFPercentage(2.5),
+  },
+  tagBox: {
+    height: RFPercentage(3.5),
+    borderRadius: RFPercentage(1.5),
+    width: RFPercentage(14),
+    borderWidth: RFPercentage(0.2),
+    borderColor: 'gray',
+    justifyContent: 'center',
+    margin: 5,
+  },
+  tagBoxActive: {
+    borderColor: 'blue',
+  },
+  tagText: {
+    fontSize: RFPercentage(2),
+    color: 'gray',
+    fontWeight: 'bold',
+    textAlign: 'center',
+
+  },
+  tagTextActive: {
+    color: 'blue',
+  },
+  tagModalRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
   },
 });

--- a/mobile/bulingo/app/components/quizCard.tsx
+++ b/mobile/bulingo/app/components/quizCard.tsx
@@ -25,15 +25,13 @@ export default function QuizCard(props: QuizCardProps){
 
   const handleLikePress = (id: number) => {
     props.onLikePress && props.onLikePress(id);
-    if (!props.onLikePress){
-      if(liked){
-        setLiked(false);
-        setLikes(likes - 1);
-      } 
-      else {
-        setLiked(true);
-        setLikes(likes + 1);
-      };
+    if(liked){
+      setLiked(false);
+      setLikes(likes - 1);
+    } 
+    else {
+      setLiked(true);
+      setLikes(likes + 1);
     };
   };
 


### PR DESCRIPTION
Fixes #465
This PR includes the designs for the search page. This search page is designed to be a general search for the app, showing search results for users, quizzes and forums. This is up-for-debate though, as we already have search functionality in the Quiz and Forum pages separately. Still, having a general place for searching may be nice.

 I have also added sorting and filtering options. You can sort by newest or most liked, and you can use the filters to constrain the search to certain content types and tags. The search functionality was left entirely to the backend. I have integrated the page's design with quizCard and userCard components, but forum post and comment cards have not been merged to main yet and therefore they have placeholders instead. You can find example screenshot below.
 
 
<img width="230" src="https://github.com/user-attachments/assets/596789f4-b11c-4acb-8598-03ce57904d1a">
<img width="230" src="https://github.com/user-attachments/assets/90169305-b883-4edb-bb10-99e23dfdd561">
<img width="230" src="https://github.com/user-attachments/assets/5fb2c362-b6fe-4048-a8a1-85fc3587e049">
<img width="230" src="https://github.com/user-attachments/assets/1873b308-5bea-4a25-b6d6-6cd8df8c9746">
<img width="230" src="https://github.com/user-attachments/assets/d8a71f8a-416f-4971-a73a-1e1fcb341ea5">
<img width="230" src="https://github.com/user-attachments/assets/67eacf94-4193-4985-ac80-93a8320a1402">