### PR TITLE
refactor(mobile): Remove Navigation Bar from Login and Register Pages

### DIFF
--- a/mobile/bulingo/app/login.tsx
+++ b/mobile/bulingo/app/login.tsx
@@ -1,6 +1,5 @@
 import React, {useState, createContext, useContext} from 'react';
 import {Pressable, StyleSheet, Text, View, TextInput, TouchableWithoutFeedback, ActivityIndicator} from 'react-native';
-import Navbar from "./navbar";
 import {router} from 'expo-router'
 import TokenManager from './TokenManager'; // Import the TokenManager
 
@@ -69,7 +68,6 @@ export default function Home() {
         </TouchableWithoutFeedback>
       )}
 
-      <View style={styles.navbarContainer}><Navbar/></View>
         <View style={styles.page}>
         
 
@@ -109,7 +107,7 @@ export default function Home() {
             </View>
             <Text style={styles.smallText}>Don't have an account?</Text>
             <View style={styles.buttonContainer}>
-              <Pressable style={[styles.rectangularButton, {backgroundColor: 'gray'}]} onPress={handleRegister} disabled={true}>
+              <Pressable style={[styles.rectangularButton]} onPress={handleRegister}>
                 <Text style={styles.buttonText}>Register</Text>
               </Pressable>
             </View>

--- a/mobile/bulingo/app/login.tsx
+++ b/mobile/bulingo/app/login.tsx
@@ -162,7 +162,9 @@ const styles = StyleSheet.create({
   },
   titleText: {
     textAlign: 'center',
-    fontSize: 30,
+    fontSize: 36,
+    color: '#3944FD',
+    fontWeight: 'bold',
   },
   userInputText: {
     fontSize: 16,

--- a/mobile/bulingo/app/register.tsx
+++ b/mobile/bulingo/app/register.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { View, Text, TextInput, TouchableOpacity, Image, StyleSheet, TouchableWithoutFeedback, Keyboard } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { useNavigation } from '@react-navigation/native';
-import Navbar from "./navbar";
 import {router} from 'expo-router';
 
 // const SIGNUP_URL = "http://161.35.208.249:8000/signup/";
@@ -66,6 +65,10 @@ const Register = () => {
     }
   };
 
+  const handleReturnHome = () => {
+    router.navigate('/');
+  }
+
   useEffect (() => {
     if (!isTyping) {
         updateFormValidity();
@@ -124,7 +127,6 @@ const Register = () => {
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
     <View style={styles.container}>
-      <View style={styles.navbarContainer}><Navbar/></View>
 
       <Text style={styles.header}>Register</Text>
 
@@ -206,6 +208,15 @@ const Register = () => {
         >
         <Text style={styles.buttonText}>Sign Up</Text>
       </TouchableOpacity>
+
+      <TouchableOpacity 
+        style={[styles.button, { marginTop: 10 }]} // Add margin top
+        onPress={handleReturnHome}
+        
+        >
+          <Text style={styles.buttonText}>Return Home</Text>
+        </TouchableOpacity>
+
     </View>
     </TouchableWithoutFeedback>
   );
@@ -240,7 +251,7 @@ const styles = StyleSheet.create({
     minHeight : 30,
     backgroundColor: '#E8E8E8',
     borderRadius: 10,
-    flex: 0.14,
+    flex: 0.10,
     marginRight: 10,
     paddingLeft: 10,
   },
@@ -303,3 +314,4 @@ const styles = StyleSheet.create({
 });
 
 export default Register;
+


### PR DESCRIPTION
Fixes #569.


- The navigation bar has been removed from the Login and Register pages.
- The style of the "Log In" text has been changed to align with the "Register" text.
- The Register button on the Log In page has been enabled.
- A Return Home button has been added to the Register page.