### PR TITLE
test(mobile: add unit tests for card components

### DIFF
--- a/mobile/bulingo/app/(tabs)/profile/userCard.test.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/userCard.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import UserCard from './userCard';
+
+test('renders the user card and handles presses', () => {
+  const mockFn1 = jest.fn();
+  const mockFn2 = jest.fn();
+
+  const { getByTestId } = render(
+  <UserCard 
+    username='User123' 
+    name='Jake'
+    level='A2'
+    profilePictureUri='https://testuri.com'
+    buttonText="Follow"
+    buttonStyleNo={1}
+    onButtonPress={mockFn1}    
+    onCardPress={mockFn2}
+  />);
+
+  const button1 = getByTestId('button');
+
+  fireEvent.press(button1);
+
+  expect(mockFn1).toHaveBeenCalled();
+});
+
+test('renders the user card and includes all the input text', () => {
+  const mockFn1 = jest.fn();
+  const mockFn2 = jest.fn();
+
+  const username = 'User123';
+  const name = 'Jake';
+  const level = 'A2'
+  const buttonText = "Unfollow";
+
+  const { getByText } = render(
+    <UserCard 
+    username={username}
+    name={name}
+    level={level}
+    profilePictureUri='https://testuri.com'
+    buttonText={buttonText}
+    buttonStyleNo={1}
+    onButtonPress={mockFn1}    
+    onCardPress={mockFn2}
+  />);
+
+  expect(getByText(username)).toBeTruthy();
+  expect(getByText(name)).toBeTruthy();
+  expect(getByText(level)).toBeTruthy();
+  expect(getByText(buttonText)).toBeTruthy();
+});

--- a/mobile/bulingo/app/(tabs)/profile/userCard.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/userCard.tsx
@@ -51,7 +51,7 @@ const UserCard = (props: UserCardProps) => {
   
 
   return (
-    <TouchableOpacity style={styles.followerContainer} onPress={handleCardPress}>
+    <TouchableOpacity style={styles.followerContainer} onPress={handleCardPress} testID='card'>
       <View style={styles.profilePictureContainer}>
         <Image 
           source={{
@@ -69,7 +69,7 @@ const UserCard = (props: UserCardProps) => {
           <Text style={styles.levelText}>{props.level}</Text>
         </View>
         <View style={styles.buttonContainer}>
-          <TouchableOpacity style={[styles.buttonStyle, buttonStyleAddOn]} onPress={handleButtonPress}>
+          <TouchableOpacity style={[styles.buttonStyle, buttonStyleAddOn]} onPress={handleButtonPress} testID='button'>
             <Text style={[styles.buttonText, {color: buttonTextColor}]}>{props.buttonText}</Text>
           </TouchableOpacity>
         </View>

--- a/mobile/bulingo/app/components/commentcard.test.tsx
+++ b/mobile/bulingo/app/components/commentcard.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import CommentCard from './commentcard';
+
+test('renders the commentcard and handles press', () => {
+  const mockFn = jest.fn();
+
+  const { getByTestId } = render(
+  <CommentCard 
+    onUpvote={mockFn} 
+    id={0} 
+    isBookmarked={false} 
+    username='test' 
+    comment='test comment'
+    liked={true}
+    likes={15}
+  />);
+
+  const button = getByTestId('likeButton');
+  fireEvent.press(button);
+
+  expect(mockFn).toHaveBeenCalled(); // Verify the onPress function is called
+});

--- a/mobile/bulingo/app/components/commentcard.test.tsx
+++ b/mobile/bulingo/app/components/commentcard.test.tsx
@@ -21,3 +21,22 @@ test('renders the commentcard and handles press', () => {
 
   expect(mockFn).toHaveBeenCalled(); // Verify the onPress function is called
 });
+
+test('renders commentcard and includes all the input props', () => {
+  const mockFn = jest.fn();
+  const uname = 'test username';
+  const comment = 'test comment';
+  const { getByText } = render(
+    <CommentCard 
+      onUpvote={mockFn}
+      id={0} 
+      isBookmarked={false} 
+      username={uname} 
+      comment={comment}
+      liked={true}
+      likes={15}
+    />);
+
+  expect(getByText(uname)).toBeTruthy();
+  expect(getByText(comment)).toBeTruthy();
+});

--- a/mobile/bulingo/app/components/commentcard.tsx
+++ b/mobile/bulingo/app/components/commentcard.tsx
@@ -47,7 +47,7 @@ const CommentCard: React.FC<CommentCardProps> = ({ id, isBookmarked: initialBook
                     </TouchableOpacity>
                     <Text style={styles.upvoteCount}>{upvoteCount}</Text> */}
 
-            <TouchableOpacity style={styles.likeButton} onPress={() => onUpvote(id)}>
+            <TouchableOpacity style={styles.likeButton} onPress={() => onUpvote(id)} testID='likeButton'>
                         <Text style={styles.quizLikes}>
                         <Image source={liked ? require('../../assets/images/like-2.png') : require('../../assets/images/like-1.png')}style={styles.icon} /> 
                                           {/* <Image source={ require('../../assets/images/like-2.png')}style={styles.icon} />  */}

--- a/mobile/bulingo/app/components/postcard.test.tsx
+++ b/mobile/bulingo/app/components/postcard.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import PostCard from './postcard';
+
+test('renders the post card and handles presses', () => {
+  const mockFn1 = jest.fn();
+  const mockFn2 = jest.fn();
+  const mockFn3 = jest.fn();
+
+
+
+  const { getByTestId } = render(
+  <PostCard 
+    onUpvote={mockFn1} 
+    id={'test id'} 
+    isBookmarked={false} 
+    author='test author' 
+    title='test title'
+    liked={true}
+    likes={15}
+    tags={['tag1', 'tag2', 'tag3']}
+    onBookmark={mockFn2}
+    feedOrPost={''}
+    onPress={mockFn3}    
+  />);
+
+  const button1 = getByTestId('likeButton');
+  const button2 = getByTestId('bookmarkButton');
+  const button3 = getByTestId('card');
+
+  fireEvent.press(button1);
+  fireEvent.press(button2);
+  fireEvent.press(button3);
+
+  expect(mockFn1).toHaveBeenCalled(); 
+  expect(mockFn2).toHaveBeenCalled(); 
+  expect(mockFn3).toHaveBeenCalled(); 
+
+});
+
+test('renders post card and includes all the input text', () => {
+  const mockFn1 = jest.fn();
+  const mockFn2 = jest.fn();
+  const mockFn3 = jest.fn();
+
+  const title = 'test title';
+  const author = 'testauthor';
+  const tags = ['tag1', 'tag2', 'tag3'];
+
+  const { getByText } = render(
+    <PostCard 
+      onUpvote={mockFn1} 
+      id={'test id'} 
+      isBookmarked={false} 
+      author={author}
+      title={title}
+      liked={true}
+      likes={15}
+      tags={tags}
+      onBookmark={mockFn2}
+      feedOrPost={''}
+      onPress={mockFn3}    
+    />);
+
+  expect(getByText(title)).toBeTruthy();
+  expect(getByText(`by ${author}`)).toBeTruthy();
+  tags.forEach(tag => expect(getByText(tag)).toBeTruthy());
+});

--- a/mobile/bulingo/app/components/postcard.tsx
+++ b/mobile/bulingo/app/components/postcard.tsx
@@ -33,7 +33,7 @@ const PostCard: React.FC<PostCardProps> = ({
 
 
   return (
-    <TouchableOpacity onPress={onPress}>
+    <TouchableOpacity onPress={onPress} testID='card'>
       <View style={styles.cardContainer}>
         <View style={styles.header}>
           <Text style={styles.title}>{title}</Text>
@@ -53,14 +53,14 @@ const PostCard: React.FC<PostCardProps> = ({
               <Text style={styles.upvoteCount}>{likes}</Text>
             </TouchableOpacity>
              */}
-            <TouchableOpacity style={styles.likeButton} onPress={() => onUpvote(id)}>
+            <TouchableOpacity style={styles.likeButton} onPress={() => onUpvote(id)} testID={'likeButton'}>
              <Text style={styles.quizLikes}>
             <Image source={liked ? require('../../assets/images/like-2.png') : require('../../assets/images/like-1.png')}style={styles.icon} /> 
             {likes}
             </Text>
             </TouchableOpacity>
 
-            <TouchableOpacity onPress={onBookmark} style={styles.bookmarkButton}>
+            <TouchableOpacity onPress={onBookmark} style={styles.bookmarkButton} testID={'bookmarkButton'}>
               <FontAwesome 
                 name={isBookmarked ? 'bookmark' : 'bookmark-o'} 
                 size={20} 

--- a/mobile/bulingo/app/components/quizCard.test.tsx
+++ b/mobile/bulingo/app/components/quizCard.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import QuizCard from './quizCard';
+
+test('renders the quiz card and handles presses', () => {
+  const mockFn1 = jest.fn();
+  const mockFn2 = jest.fn();
+  const mockFn3 = jest.fn();
+
+  const { getByTestId } = render(
+  <QuizCard 
+    id={0} 
+    author='test author' 
+    title='test title'
+    level='A2'
+    description='test description'
+    liked={true}
+    likes={15}
+    onLikePress={mockFn1}    
+    onBookmarkPress={mockFn2}
+    onQuizPress={mockFn3}    
+  />);
+
+  const button1 = getByTestId('likeButton');
+  const button2 = getByTestId('bookmarkButton');
+  const button3 = getByTestId('quiz');
+
+  fireEvent.press(button1);
+  fireEvent.press(button2);
+  fireEvent.press(button3);
+
+  expect(mockFn1).toHaveBeenCalled(); 
+  expect(mockFn2).toHaveBeenCalled(); 
+  expect(mockFn3).toHaveBeenCalled(); 
+
+});
+
+test('renders quiz card and includes all the input text', () => {
+  const mockFn1 = jest.fn();
+  const mockFn2 = jest.fn();
+  const mockFn3 = jest.fn();
+
+  const title = 'test title';
+  const author = 'testauthor';
+  const level = "A2";
+  const desc = "test description";
+  const likes = 15;
+
+  const { getByText } = render(
+    <QuizCard 
+    id={0} 
+    author={author}
+    title={title}
+    level={level}
+    description={desc}
+    liked={true}
+    likes={15}
+    onLikePress={mockFn1}    
+    onBookmarkPress={mockFn2}
+    onQuizPress={mockFn3}    
+  />);
+
+  expect(getByText(title)).toBeTruthy();
+  expect(getByText(`by ${author}`)).toBeTruthy();
+  expect(getByText(level)).toBeTruthy();
+  expect(getByText(desc)).toBeTruthy();
+  expect(getByText(likes.toString())).toBeTruthy();
+});

--- a/mobile/bulingo/app/components/quizCard.tsx
+++ b/mobile/bulingo/app/components/quizCard.tsx
@@ -47,6 +47,7 @@ export default function QuizCard(props: QuizCardProps){
     <TouchableOpacity
       style={[styles.quizItem, styles.elevation]}
       onPress={() => handleQuizPress(props.id)}
+      testID='quiz'
     >
       <View style={styles.quizTop}>
         <Text style={styles.quizTitle}>{props.title}</Text>
@@ -57,14 +58,14 @@ export default function QuizCard(props: QuizCardProps){
           <Text style={styles.quizAuthor}>by {props.author}</Text>
           <Text style={styles.quizLevel}>{props.level}</Text>
         </View>
-        <TouchableOpacity style={styles.likeButton} onPress={() => handleLikePress(props.id)}>
+        <TouchableOpacity style={styles.likeButton} onPress={() => handleLikePress(props.id)} testID='likeButton'>
           <Text style={styles.quizLikes}>
           <Image source={liked ? require('@/assets/images/like-2.png') : require('@/assets/images/like-1.png')}style={styles.icon} /> {likes}
           </Text>
         </TouchableOpacity>
 
         {/* Touchable Bookmark Icon at the bottom right */}
-        <TouchableOpacity style={styles.bookmarkButton} onPress={() => handleBookmarkPress(props.id)}>
+        <TouchableOpacity style={styles.bookmarkButton} onPress={() => handleBookmarkPress(props.id)} testID='bookmarkButton'>
           <Image source={require('@/assets/images/bookmark-icon.png')} style={styles.icon} />
         </TouchableOpacity>
       </View>

--- a/mobile/bulingo/package-lock.json
+++ b/mobile/bulingo/package-lock.json
@@ -41,6 +41,7 @@
       "devDependencies": {
         "@babel/core": "^7.20.0",
         "@testing-library/react-native": "^12.8.1",
+        "@types/jest": "^29.5.14",
         "@types/react": "~18.2.45",
         "jest": "^29.7.0",
         "jest-expo": "~51.0.4",
@@ -7591,6 +7592,17 @@
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/jsdom": {

--- a/mobile/bulingo/package-lock.json
+++ b/mobile/bulingo/package-lock.json
@@ -40,10 +40,11 @@
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
+        "@testing-library/react-native": "^12.8.1",
         "@types/react": "~18.2.45",
-        "jest": "^29.2.1",
+        "jest": "^29.7.0",
         "jest-expo": "~51.0.4",
-        "react-test-renderer": "18.2.0",
+        "react-test-renderer": "^18.2.0",
         "tailwindcss": "^3.4.3",
         "typescript": "~5.3.3"
       }
@@ -7477,6 +7478,29 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@testing-library/react-native": {
+      "version": "12.8.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-12.8.1.tgz",
+      "integrity": "sha512-/7PIFCpeqAD3j7nzKQhZtm1T6RR/O/tB1We7JHtYP5RpTBj8rPitEpt6xGrD8R0ymOh+DxDKK7Zovfv5uDSRWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^29.7.0",
+        "pretty-format": "^29.7.0",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "jest": ">=28.0.0",
+        "react": ">=16.8.0",
+        "react-native": ">=0.59",
+        "react-test-renderer": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -12622,6 +12646,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -15995,6 +16020,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -17883,6 +17918,7 @@
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
       "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "react-is": "^18.2.0",
         "react-shallow-renderer": "^16.15.0",
@@ -17969,6 +18005,20 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/regenerate": {
@@ -19039,6 +19089,19 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/mobile/bulingo/package.json
+++ b/mobile/bulingo/package.json
@@ -10,7 +10,8 @@
     "test": "jest --watchAll"
   },
   "jest": {
-    "preset": "jest-expo"
+    "preset": "jest-expo",
+    "setupFilesAfterEnv": ["@testing-library/jest-native/extend-expect"]
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",
@@ -45,10 +46,11 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
+    "@testing-library/react-native": "^12.8.1",
     "@types/react": "~18.2.45",
-    "jest": "^29.2.1",
+    "jest": "^29.7.0",
     "jest-expo": "~51.0.4",
-    "react-test-renderer": "18.2.0",
+    "react-test-renderer": "^18.2.0",
     "tailwindcss": "^3.4.3",
     "typescript": "~5.3.3"
   },

--- a/mobile/bulingo/package.json
+++ b/mobile/bulingo/package.json
@@ -10,8 +10,7 @@
     "test": "jest --watchAll"
   },
   "jest": {
-    "preset": "jest-expo",
-    "setupFilesAfterEnv": ["@testing-library/jest-native/extend-expect"]
+    "preset": "jest-expo"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",
@@ -47,6 +46,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@testing-library/react-native": "^12.8.1",
+    "@types/jest": "^29.5.14",
     "@types/react": "~18.2.45",
     "jest": "^29.7.0",
     "jest-expo": "~51.0.4",


### PR DESCRIPTION
Fixes #586
This PR includes unit tests for userCard, commentcard, postcard and quizCard components. The unit tests cover the various buttons and the texts that should be present on the screen. 

This PR also includes slight changes to the components it is testing, but these should have no behavioral or visual effect, it just adds testID props to some components.

For testing, jest was used.