### PR TITLE
fix(mobile): Refresh profile page dynamically

### DIFF
--- a/mobile/bulingo/app/(tabs)/index.tsx
+++ b/mobile/bulingo/app/(tabs)/index.tsx
@@ -22,6 +22,8 @@ export default function Home() {
     useCallback(() => {
       if (searchParams?.notification == 'login_success'){
         setNotification("Login Successful!");
+      } else if (searchParams?.notification == 'register_success'){
+        setNotification("Registration Successful!");
       }
     }, [])
   );

--- a/mobile/bulingo/app/(tabs)/index.tsx
+++ b/mobile/bulingo/app/(tabs)/index.tsx
@@ -1,8 +1,9 @@
-import React, {useState} from 'react';
+import React, {useState, useCallback} from 'react';
 import {Image, TouchableOpacity, StyleSheet, Text, View, Dimensions} from 'react-native';
-import { router } from "expo-router";
+import { router, useLocalSearchParams, useFocusEffect } from "expo-router";
 import TokenManager from '../TokenManager';
 import { Shadow } from 'react-native-shadow-2';
+import Notification from '../components/topNotification';
 
 const { width, height } = Dimensions.get('window');
 
@@ -10,8 +11,20 @@ export default function Home() {
   const handleRegister = () => {
     router.navigate("/register");
   };
+  const searchParams = useLocalSearchParams();
   const username = TokenManager.getUsername();
   const [logoutTrigger, setLogoutTrigger] = useState(false);
+  const [notification, setNotification] = useState<string | null>(null);
+
+
+
+  useFocusEffect(
+    useCallback(() => {
+      if (searchParams?.notification == 'login_success'){
+        setNotification("Login Successful!");
+      }
+    }, [])
+  );
 
   const handleLogOut = () => {
     console.log("logout pressed");
@@ -24,6 +37,12 @@ export default function Home() {
 
   return (
     <View style={styles.container}>
+      {notification && (
+          <Notification
+              message={notification}
+              onHide={() => setNotification(null)} // Clear notification after hiding
+          />
+      )}
       <View style={styles.page}>
       <View style={styles.profilePictureContainer}>
       <Image

--- a/mobile/bulingo/app/(tabs)/notifications.tsx
+++ b/mobile/bulingo/app/(tabs)/notifications.tsx
@@ -1,7 +1,41 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, Image, StyleSheet } from 'react-native';
+import TokenManager from '../TokenManager';
 
-const notifications = [
+function timeDifferenceToString(isoTimestamp: string): string {
+  const now: Date = new Date();
+  const target: Date = new Date(isoTimestamp);
+
+  if (isNaN(target.getTime())) {
+      return "Invalid timestamp";
+  }
+
+  const diffMs: number = target.getTime() - now.getTime(); // Difference in milliseconds
+  const absDiffMs: number = Math.abs(diffMs); // Absolute value
+  const isFuture: boolean = diffMs > 0; // True if target is in the future
+
+  // Calculate time units
+  const seconds: number = Math.floor(absDiffMs / 1000);
+  const minutes: number = Math.floor(absDiffMs / (1000 * 60));
+  const hours: number = Math.floor(absDiffMs / (1000 * 60 * 60));
+  const days: number = Math.floor(absDiffMs / (1000 * 60 * 60 * 24));
+
+  let timeString: string;
+  if (days > 0) {
+      timeString = `${days} day${days > 1 ? 's' : ''}`;
+  } else if (hours > 0) {
+      timeString = `${hours} hour${hours > 1 ? 's' : ''}`;
+  } else if (minutes > 0) {
+      timeString = `${minutes} minute${minutes > 1 ? 's' : ''}`;
+  } else {
+      timeString = `${seconds} second${seconds > 1 ? 's' : ''}`;
+  }
+
+  return isFuture ? `in ${timeString}` : `${timeString} ago`;
+}
+
+
+const dbg_notifications = [
     { id: '1', text: 'Oguz bookmarked your quiz.' },
     { id: '2', text: 'Halil followed you.' },
     { id: '3', text: 'Anil followed you.' },
@@ -30,8 +64,39 @@ const NotificationItem = ( {text} : any ) => (
 );
 
 const Notifications = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [notifications, setNotifications] = useState(dbg_notifications);
+
+  useEffect(() => {
+    const fetchFollowers = async () => {
+      try {
+        const response = await TokenManager.authenticatedFetch("user-activities-as-object/", {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+        if (response.ok){
+          const result = await response.json()
+          console.log(result);
+          console.log();
+        } else {
+          console.log(response.status)
+        };
+      } catch (error) {
+        console.error(error);
+      }
+      setIsLoading(false);
+    };
+    fetchFollowers();
+  }, []);
+
+
   return (
     <View style={styles.container}>
+      <View style={styles.titleContainer}>
+        <Text style={styles.title}>Notifications</Text>
+      </View>
       <FlatList
         data={notifications}
         renderItem={({ item }) => <NotificationItem text={item.text} />}
@@ -45,6 +110,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     padding: 16,
+    paddingTop: 40,
     backgroundColor: '#f0f0f0',
   },
   notificationContainer: {
@@ -71,6 +137,16 @@ const styles = StyleSheet.create({
   notificationText: {
     fontSize: 16,
     color: '#1a73e8', // Blue for title text
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  titleContainer: {
+    flex: 0,
+    paddingVertical: 20,
+    alignItems: 'center',
   },
 });
 

--- a/mobile/bulingo/app/(tabs)/notifications.tsx
+++ b/mobile/bulingo/app/(tabs)/notifications.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, Image, StyleSheet } from 'react-native';
 import TokenManager from '../TokenManager';
+import { FontAwesome } from '@expo/vector-icons';
+import {router} from "expo-router";
 
 function timeDifferenceToString(isoTimestamp: string): string {
   const now: Date = new Date();
@@ -36,32 +38,55 @@ function timeDifferenceToString(isoTimestamp: string): string {
 
 
 const dbg_notifications = [
-    { id: '1', text: 'Oguz bookmarked your quiz.' },
-    { id: '2', text: 'Halil followed you.' },
-    { id: '3', text: 'Anil followed you.' },
-    { id: '4', text: 'Aras bookmarked your quiz.' },
-    { id: '5', text: 'Oguz followed you.' },
-    { id: '6', text: 'Ozan liked your comment.' },
-    { id: '7', text: 'Sait bookmarked your quiz.' },
-    { id: '8', text: 'Kasap liked your post.' },
-    { id: '9', text: 'Ozan followed you.' },
-    { id: '10', text: 'Kasap followed you.' },
-    { id: '11', text: 'Sait liked your quiz.' },
-    { id: '12', text: 'Ozan bookmarked your post.' },
-    { id: '13', text: 'Kasap liked your recent quiz.' },
-    { id: '14', text: 'Sait followed you.' },
-    { id: '16', text: 'Halil bookmarked your comment.' },
-    { id: '17', text: 'Anil liked your post.' },
-  ];
+  {
+    actor: "ygz", 
+    affected_username: "ygz2",
+    object_id: 2,
+    object_type: "Profile", 
+    timestamp: "2024-11-24T17:06:46.710414Z", 
+    verb: "followed"
+  }
+];
 
-const NotificationItem = ( {text} : any ) => (
-  <View style={styles.notificationContainer}>
-    <View style={styles.profileInfoTopPictureContainer}>
-      <Image source={require('@/assets/images/profile-icon.png')} style={styles.profileInfoTopPicture} />
+const NotificationItem = ( {activity} : any ) => {
+  const ActivityToComponent = (activity: any) => {
+    const username = TokenManager.getUsername();
+    const handlePress = (user: any) => {
+      if (user == username){
+        router.navigate("/(tabs)/profile")
+      } else {
+        router.navigate('/(tabs)/profile')
+        setTimeout(() => {
+          router.push(`/(tabs)/profile/users/${user}`);
+        }, 0);
+      }
+      console.log("text Pressed");
+    };
+    return (
+      <Text style={styles.notificationText}>
+        <Text style={styles.clickableText} onPress={() => handlePress(activity.actor)}>
+          {activity.actor==username ? "You" : activity.actor}
+        </Text>{' '}
+        {activity.verb}{' '}
+        <Text style={styles.clickableText} onPress={() => handlePress(activity.affected_username)}>
+          {activity.affected_username==username ? "You" : activity.affected_username}
+        </Text>{' '}
+        {timeDifferenceToString(activity.timestamp)}
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.notificationContainer}>
+      <View style={styles.profileInfoTopPictureContainer}>
+        <FontAwesome name='bell' size={28}/>
+      </View>
+      {ActivityToComponent(activity)}
     </View>
-    <Text style={styles.notificationText}>{text}</Text>
-  </View>
-);
+  );
+}
+
+
 
 const Notifications = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -79,7 +104,7 @@ const Notifications = () => {
         if (response.ok){
           const result = await response.json()
           console.log(result);
-          console.log();
+          setNotifications(result.activities);
         } else {
           console.log(response.status)
         };
@@ -99,8 +124,8 @@ const Notifications = () => {
       </View>
       <FlatList
         data={notifications}
-        renderItem={({ item }) => <NotificationItem text={item.text} />}
-        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <NotificationItem activity={item} />}
+        keyExtractor={(item) => item.timestamp}
       />
     </View>
   );
@@ -136,7 +161,7 @@ const styles = StyleSheet.create({
   },
   notificationText: {
     fontSize: 16,
-    color: '#1a73e8', // Blue for title text
+    color: 'black',
   },
   title: {
     fontSize: 28,
@@ -147,6 +172,10 @@ const styles = StyleSheet.create({
     flex: 0,
     paddingVertical: 20,
     alignItems: 'center',
+  },
+  clickableText: {
+    fontSize: 16,
+    color: '#1a73e8', // Blue for clickable text
   },
 });
 

--- a/mobile/bulingo/app/(tabs)/notifications.tsx
+++ b/mobile/bulingo/app/(tabs)/notifications.tsx
@@ -79,7 +79,7 @@ const NotificationItem = ( {activity} : any ) => {
   return (
     <View style={styles.notificationContainer}>
       <View style={styles.profileInfoTopPictureContainer}>
-        <FontAwesome name='bell' size={28}/>
+        <Image source={require("@/assets/images/profile-icon.png")} style={styles.profileInfoTopPicture}/>
       </View>
       {ActivityToComponent(activity)}
     </View>

--- a/mobile/bulingo/app/(tabs)/profile/bookmarkedPostsAndComments.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/bookmarkedPostsAndComments.tsx
@@ -1,27 +1,23 @@
 import React, { useState, useEffect } from 'react';
 import {Text, StyleSheet, FlatList, View, TouchableWithoutFeedback, ActivityIndicator } from 'react-native';
-
-type BookmarkedPostsAndCommentsInfoPlaceholder = {  // Placeholder, remove when post/comment Card is ready.
-  name: string,
-};
+import TokenManager from '@/app/TokenManager';
 
 export default function Followers() {
   const [isLoading, setIsLoading] = useState(true);
-  const [bookmarkedPostsAndComments, setBoormarkedPostAndComments] = useState<BookmarkedPostsAndCommentsInfoPlaceholder[]>([
-    {name: 'Post 1'},  // Placeholder
-    {name: 'Post 2'},  // Placeholder
-    {name: 'Comment 1'},  // Placeholder
-    {name: 'Comment 2'},  // Placeholder
-  ])
+  const [bookmarkedPostsAndComments, setBoormarkedPostAndComments] = useState<any[]>([])
 
   useEffect(() => {
-    const ENDPOINT_URL = "http://161.35.208.249:8000/bookmarkedpostsandcomments";  // Placeholder
     const fetchFollowers = async () => {
+      const username = TokenManager.getUsername();
+      if(username === undefined){
+        console.error('username is undefined!');
+        return
+      }
       const params = {
-        // TODO
-       };
+        'user': username,
+      }
       try {
-        const response = await fetch(ENDPOINT_URL, {
+        const response = await TokenManager.authenticatedFetch("get_bookmarked_posts/", {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -30,7 +26,8 @@ export default function Followers() {
         });
 
         if (response.ok){
-          setBoormarkedPostAndComments(await response.json());
+          const result = await response.json();
+          setBoormarkedPostAndComments(result);
         } else {
           console.log(response.status)
         };

--- a/mobile/bulingo/app/(tabs)/profile/bookmarkedQuizzes.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/bookmarkedQuizzes.tsx
@@ -2,33 +2,27 @@ import React, { useState, useEffect } from 'react';
 import {Text, StyleSheet, FlatList, View, TouchableWithoutFeedback, ActivityIndicator } from 'react-native';
 import { QuizInfo } from '.';
 import QuizCard from '@/app/components/quizCard';
+import TokenManager from '@/app/TokenManager';
 
 
 export default function Followers() {
   const [isLoading, setIsLoading] = useState(true);
-  const [bookmarkedQuizzes, setBoormarkedQuizzes] = useState<QuizInfo[]>([
-    { id: 4, title: 'Plants', description: 'Test your plant knowledge', author: 'Halil', level: 'A2', likes: 300, liked: true },
-    { id: 5, title: 'Transport', description: 'Types of transport', author: 'Alex', level: 'B1', likes: 4, liked: false },
-    { id: 6, title: 'Food', description: 'Learn about foods', author: 'Oguz', level: 'A2', likes: 135, liked: true },
-  ])
+  const [bookmarkedQuizzes, setBoormarkedQuizzes] = useState<QuizInfo[]>([])
 
   useEffect(() => {
-    const ENDPOINT_URL = "http://161.35.208.249:8000/bookmarkedquizzes";  // Placeholder
     const fetchFollowers = async () => {
-      const params = {
-        // TODO
-       };
+      const url = "quiz/bookmarks/"
       try {
-        const response = await fetch(ENDPOINT_URL, {
-          method: 'POST',
+        const response = await TokenManager.authenticatedFetch(url, {
+          method: 'GET',
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify(params),
         });
 
         if (response.ok){
-          setBoormarkedQuizzes(await response.json());
+          const result = await response.json()
+          console.log('Result is', result);
         } else {
           console.log(response.status)
         };
@@ -55,7 +49,8 @@ export default function Followers() {
       data={bookmarkedQuizzes}
       renderItem={({item}) => {  // Placeholder, replace with quiz card
         return (
-          <QuizCard {...item}/>
+          <QuizCard id={item.id} author={item.author.username} title={item.title} level={item.level} 
+              description={item.description} liked={item.is_liked} likes={item.like_count}/>
         );
       }}
       ListHeaderComponent={

--- a/mobile/bulingo/app/(tabs)/profile/bookmarkedQuizzes.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/bookmarkedQuizzes.tsx
@@ -22,7 +22,6 @@ export default function Followers() {
 
         if (response.ok){
           const result = await response.json()
-          console.log('Result is', result);
         } else {
           console.log(response.status)
         };

--- a/mobile/bulingo/app/(tabs)/profile/editProfile.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/editProfile.tsx
@@ -5,6 +5,7 @@ import { RFPercentage } from 'react-native-responsive-fontsize';
 import { ImageSourceOverlay } from './imageSourceOverlay';
 import { Dropdown } from 'react-native-element-dropdown';
 import TokenManager from '@/app/TokenManager';
+import {router} from 'expo-router';
 
 type UserInfo = {
   name: string,
@@ -61,7 +62,6 @@ export default function EditProfile() {
       // Convert the parameters to a query string
       const queryString = new URLSearchParams(params).toString();
       const urlWithParams = `${baseUrl}?${queryString}`;
-      console.log(`URL = ${urlWithParams}`)
       try {
         const response = await TokenManager.authenticatedFetch(urlWithParams, {
           method: 'GET',
@@ -70,7 +70,6 @@ export default function EditProfile() {
           },
         });
         const res = await response.json();
-        console.log(res);
         if (response.ok){
           setUserInfo(res);
         } else {
@@ -97,8 +96,6 @@ export default function EditProfile() {
       quality: 1,
     });
 
-    console.log(result);
-
     if (!result.canceled) {
       setImage(result.assets[0].uri);
       closeModal();
@@ -113,7 +110,6 @@ export default function EditProfile() {
       quality: 1,
     });
 
-    console.log(result);
 
     if (!result.canceled) {
       setImage(result.assets[0].uri);
@@ -128,8 +124,6 @@ export default function EditProfile() {
       'level': userInfo.level,
       'bio': userInfo.bio,
      };
-    console.log(userInfo);
-    console.log(params);
     try {
       const response = await TokenManager.authenticatedFetch('profile/update/', {
         method: 'POST',
@@ -139,9 +133,9 @@ export default function EditProfile() {
         body: JSON.stringify(params)
       });
       const res = await response.json();
-      console.log("On Save Changes", res);
       if (response.ok){
         setUserInfo(res);
+        router.navigate({pathname: '/(tabs)/profile', params: {key: Date.now()}})
       } else {
         console.log(response.status)
       };

--- a/mobile/bulingo/app/(tabs)/profile/followers.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/followers.tsx
@@ -64,8 +64,8 @@ export default function Followers() {
             username={item.username} 
             profilePictureUri={item.profilePictureUri} 
             level={item.level}
-            buttonText={'Unfollow'}
-            buttonStyleNo={1}
+            buttonText={'Follow'}
+            buttonStyleNo={2}
           />
         );
       }}

--- a/mobile/bulingo/app/(tabs)/profile/followers.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/followers.tsx
@@ -12,13 +12,7 @@ type UserInfoCompact = {
 export default function Followers() {
   const [isLoading, setIsLoading] = useState(true);
   const [followers, setFollowers] = useState<UserInfoCompact[]>([
-    {username: 'ygz1', name: 'Yagiz Guldal', level: 'A1', profilePictureUri:"https://static.vecteezy.com/system/resources/thumbnails/024/646/930/small_2x/ai-generated-stray-cat-in-danger-background-animal-background-photo.jpg"},
-    {username: 'ygz2', name: 'Yagiz Guldal', level: 'A1', profilePictureUri:"https://static.vecteezy.com/system/resources/thumbnails/024/646/930/small_2x/ai-generated-stray-cat-in-danger-background-animal-background-photo.jpg"},
-    {username: 'ygz3', name: 'Yagiz Guldal', level: 'A1', profilePictureUri:"https://static.vecteezy.com/system/resources/thumbnails/024/646/930/small_2x/ai-generated-stray-cat-in-danger-background-animal-background-photo.jpg"},
-    {username: 'ygz4', name: 'Yagiz Guldal', level: 'A1', profilePictureUri:"https://static.vecteezy.com/system/resources/thumbnails/024/646/930/small_2x/ai-generated-stray-cat-in-danger-background-animal-background-photo.jpg"},
-    {username: 'ygz5', name: 'Yagiz Guldal', level: 'A1', profilePictureUri:"https://static.vecteezy.com/system/resources/thumbnails/024/646/930/small_2x/ai-generated-stray-cat-in-danger-background-animal-background-photo.jpg"},
-    {username: 'ygz6', name: 'Yagiz Guldal', level: 'A1', profilePictureUri:"https://static.vecteezy.com/system/resources/thumbnails/024/646/930/small_2x/ai-generated-stray-cat-in-danger-background-animal-background-photo.jpg"},
-    {username: 'ygz7', name: 'Yagiz Guldal', level: 'A1', profilePictureUri:"https://static.vecteezy.com/system/resources/thumbnails/024/646/930/small_2x/ai-generated-stray-cat-in-danger-background-animal-background-photo.jpg"},
+    {username: 'yunus', name: 'Yunus Emre', level: 'C2', profilePictureUri:"https://static.vecteezy.com/system/resources/thumbnails/024/646/930/small_2x/ai-generated-stray-cat-in-danger-background-animal-background-photo.jpg"},
   ])
 
   useEffect(() => {

--- a/mobile/bulingo/app/(tabs)/profile/followers.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/followers.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import {Text, StyleSheet, FlatList, View, Image, TouchableWithoutFeedback, ActivityIndicator } from 'react-native';
 import UserCard from './userCard';
+import TokenManager from '@/app/TokenManager';
 
 type UserInfoCompact = {
   username: string,
@@ -12,26 +13,29 @@ type UserInfoCompact = {
 export default function Followers() {
   const [isLoading, setIsLoading] = useState(true);
   const [followers, setFollowers] = useState<UserInfoCompact[]>([
-    {username: 'yunus', name: 'Yunus Emre', level: 'C2', profilePictureUri:"https://static.vecteezy.com/system/resources/thumbnails/024/646/930/small_2x/ai-generated-stray-cat-in-danger-background-animal-background-photo.jpg"},
+    {username: 'oguz', name: 'Oguz', level: 'NA', profilePictureUri:"https://static.vecteezy.com/system/resources/thumbnails/024/646/930/small_2x/ai-generated-stray-cat-in-danger-background-animal-background-photo.jpg"},
   ])
 
   useEffect(() => {
-    const ENDPOINT_URL = "http://161.35.208.249:8000/followers";  // Placeholder
     const fetchFollowers = async () => {
-      const params = {
-        // TODO
-       };
+      const username = TokenManager.getUsername();
+      if (username === undefined){
+        console.error("Username not defined!");
+        return;
+      }
+
+      const url = `profile/followers/${username}/`
       try {
-        const response = await fetch(ENDPOINT_URL, {
-          method: 'POST',
+        const response = await TokenManager.authenticatedFetch(url, {
+          method: 'GET',
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify(params),
         });
 
         if (response.ok){
-          setFollowers(await response.json());
+          const result = await response.json();
+          setFollowers(result);
         } else {
           console.log(response.status)
         };

--- a/mobile/bulingo/app/(tabs)/profile/following.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/following.tsx
@@ -1,13 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import {Text, StyleSheet, FlatList, View, Image, TouchableWithoutFeedback, ActivityIndicator } from 'react-native';
 import UserCard from './userCard';
+import TokenManager from '@/app/TokenManager';
+
 
 type UserInfoCompact = {
   username: string,
   name: string,
   level: string,
   profilePictureUri: string,
-  status: string,
+  is_followed: boolean,
 };
 
 export default function Following() {
@@ -17,20 +19,24 @@ export default function Following() {
   useEffect(() => {
     const ENDPOINT_URL = "http://161.35.208.249:8000/following";  // Placeholder
     const fetchFollowing = async () => {
-      const params = {
-        // TODO
-       };
+      const username = TokenManager.getUsername();
+      if (username === undefined){
+        console.error("Username not defined!");
+        return;
+      }
+      const url = `profile/following/${username}/`
+
       try {
-        const response = await fetch(ENDPOINT_URL, {
-          method: 'POST',
+        const response = await TokenManager.authenticatedFetch(url, {
+          method: 'GET',
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify(params),
         });
 
         if (response.ok){
-          setFollowing(await response.json());
+          const result = await response.json()
+          setFollowing(result);
         } else {
           console.log(response.status)
         };
@@ -63,8 +69,8 @@ export default function Following() {
             username={item.username} 
             profilePictureUri={item.profilePictureUri} 
             level={item.level}
-            buttonText={item.status == 'Following' ? 'Unfollow' : 'Follow'}
-            buttonStyleNo={item.status == 'Following' ? 1 : 2}
+            buttonText={item.is_followed ? 'Unfollow' : 'Follow'}
+            buttonStyleNo={item.is_followed ? 1 : 2}
           />
         );
       }}

--- a/mobile/bulingo/app/(tabs)/profile/index.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/index.tsx
@@ -90,6 +90,8 @@ export default function Profile() {
       const profileUrl = `${baseUrl}?${queryString}`;
 
       const createdQuizUrl = `quiz/created/${username}/`;
+      const solvedQuizUrl = `quiz/solved/${username}/`;
+      let updatedUserInfo;
 
       try {
         const profileRequest = await TokenManager.authenticatedFetch(profileUrl, {
@@ -100,10 +102,11 @@ export default function Profile() {
         });
         const profileResponse = await profileRequest.json();
         if (profileRequest.ok){
-          setUserInfo(profileResponse);
+          updatedUserInfo = profileResponse
         } else {
           console.log(profileRequest.status)
         };
+
         const createdQuizRequest = await TokenManager.authenticatedFetch(createdQuizUrl, {
           method: 'GET',
           headers: {
@@ -112,10 +115,26 @@ export default function Profile() {
         });
         const createdQuizResponse = await createdQuizRequest.json()
         if (createdQuizRequest.ok){
-          setUserInfo({...userInfo, createdQuizzes: createdQuizResponse});
+          updatedUserInfo = {...updatedUserInfo, createdQuizzes: createdQuizResponse}
         } else {
           console.log(createdQuizResponse.status)
         };
+        
+        const solvedQuizRequest = await TokenManager.authenticatedFetch(solvedQuizUrl, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+        const solvedQuizResponse = await solvedQuizRequest.json()
+        console.log(solvedQuizResponse);
+        if (solvedQuizRequest.ok){
+          setUserInfo({...updatedUserInfo, solvedQuizzes: solvedQuizResponse});
+        } else {
+          console.log(createdQuizResponse.status)
+        };
+
+
       } catch (error) {
         console.error(error);
       }

--- a/mobile/bulingo/app/(tabs)/profile/index.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/index.tsx
@@ -9,8 +9,8 @@ const debugUserInfo: UserInfo = {
   name: 'Yagiz Guldal',
   about: "Hello, I am an avid language learner. I am trying my best to learn English.",
   level: 'B1',
-  followerCount: 20,
-  followingCount: 25,
+  follower_count: 20,
+  following_count: 25,
   createdQuizzes: [
     { id: 1, title: 'Food', description: 'Learn about foods', author: 'Oguz', level: 'A2', likes: 135, liked: true },
     { id: 2, title: 'Animals', description: 'Our furry friends!', author: 'Aras', level: 'A2', likes: 12, liked: false },
@@ -35,8 +35,8 @@ type UserInfo = {
   name: string,
   about: string,
   level: string,
-  followerCount: number,
-  followingCount: number,
+  follower_count: number,
+  following_count: number,
   createdQuizzes: QuizInfo[],  // Placeholder
   solvedQuizzes: QuizInfo[],  // Placeholder
   postsAndComments: {id: number, desc: string}[],  // Placeholder
@@ -83,17 +83,28 @@ export default function Profile() {
 
   useEffect(() => {
     const fetchProfileInfo = async () => {
+      const username = TokenManager.getUsername()
+      if (username === null){
+        console.error("username is null")
+        return
+      }
       const params = {
-        'user': TokenManager.getUsername(),
+        'user': username,
        };
-       console.log(await TokenManager.getAccessToken());
+
+      const baseUrl = 'profile/'; // Replace with your API endpoint
+
+      // Convert the parameters to a query string
+      const queryString = new URLSearchParams(params).toString();
+      const urlWithParams = `${baseUrl}?${queryString}`;
+      console.log(`URL = ${urlWithParams}`)
+
       try {
-        const response = await TokenManager.authenticatedFetch('profile/', {
-          method: 'POST',
+        const response = await TokenManager.authenticatedFetch(urlWithParams, {
+          method: 'GET',
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify(params),
         });
         const res = await response.json();
         console.log(res);
@@ -150,8 +161,8 @@ export default function Profile() {
             name={userInfo.name}
             level={userInfo.level}
             about={userInfo.about}
-            followerCount={userInfo.followerCount}
-            followingCount={userInfo.followingCount}
+            followerCount={userInfo.follower_count}
+            followingCount={userInfo.following_count}
           />
           <Tabs tab={tab} setTab={setTab}/>
         </>
@@ -191,7 +202,7 @@ const ProfileInfo = (props:ProfileInfoProps) => {
         </View>
         <View style={styles.profileInfoTopFollowContainer}>
           <View style={styles.profileInfoTopFollowItemContainer}>
-            <Text style={styles.followItemNumberText}>{props.level}</Text>
+            <Text style={styles.followItemNumberText}>{props.level == 'NA' ? 'N/A' : props.level}</Text>
             <Text style={styles.followItemDescriptionText}>Level</Text>
           </View>
           <TouchableOpacity style={styles.profileInfoTopFollowItemContainer} onPress={handleFollowersPress}>

--- a/mobile/bulingo/app/(tabs)/profile/index.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/index.tsx
@@ -7,7 +7,7 @@ import TokenManager from '@/app/TokenManager';
 
 const debugUserInfo: UserInfo = {
   name: 'Yagiz Guldal',
-  about: "Hello, I am an avid language learner. I am trying my best to learn English.",
+  bio: "Hello, I am an avid language learner. I am trying my best to learn English.",
   level: 'B1',
   follower_count: 20,
   following_count: 25,
@@ -33,13 +33,15 @@ const debugUserInfo: UserInfo = {
 
 type UserInfo = {
   name: string,
-  about: string,
+  bio: string,
   level: string,
   follower_count: number,
   following_count: number,
   createdQuizzes: QuizInfo[],  // Placeholder
   solvedQuizzes: QuizInfo[],  // Placeholder
   postsAndComments: {id: number, desc: string}[],  // Placeholder
+  comments: any[],
+  posts: any[],
 };
 
 export type QuizInfo = {
@@ -110,6 +112,7 @@ export default function Profile() {
         console.log(res);
         if (response.ok){
           setUserInfo(res);
+          console.log('User Info: \n', userInfo)
         } else {
           console.log(response.status)
         };
@@ -160,7 +163,7 @@ export default function Profile() {
           <ProfileInfo
             name={userInfo.name}
             level={userInfo.level}
-            about={userInfo.about}
+            about={userInfo.bio}
             followerCount={userInfo.follower_count}
             followingCount={userInfo.following_count}
           />

--- a/mobile/bulingo/app/(tabs)/profile/index.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/index.tsx
@@ -68,21 +68,10 @@ export function isQuizInfo(object: any){
 };
 
 export default function Profile() {
-  /* 
-  Things we need to fetch for this page:
-  Send the access token, refresh token (maybe) and userId for this user. Get:
-   - Name
-   - Follower Count
-   - Following Count
-   - Created Quizzes
-   - Solved Quizzes
-   - Posts and Comments
-  */
-
   const [userInfo, setUserInfo] = useState<UserInfo>(debugUserInfo);
   const [tab, setTab] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
-
+  
   useEffect(() => {
     const fetchProfileInfo = async () => {
       const username = TokenManager.getUsername()
@@ -99,7 +88,6 @@ export default function Profile() {
       // Convert the parameters to a query string
       const queryString = new URLSearchParams(params).toString();
       const urlWithParams = `${baseUrl}?${queryString}`;
-      console.log(`URL = ${urlWithParams}`)
 
       try {
         const response = await TokenManager.authenticatedFetch(urlWithParams, {
@@ -109,10 +97,8 @@ export default function Profile() {
           },
         });
         const res = await response.json();
-        console.log(res);
         if (response.ok){
           setUserInfo(res);
-          console.log('User Info: \n', userInfo)
         } else {
           console.log(response.status)
         };
@@ -159,7 +145,7 @@ export default function Profile() {
       }}
       style={{backgroundColor: 'white'}}
       ListHeaderComponent={
-        <>
+        <View>
           <ProfileInfo
             name={userInfo.name}
             level={userInfo.level}
@@ -168,7 +154,7 @@ export default function Profile() {
             followingCount={userInfo.following_count}
           />
           <Tabs tab={tab} setTab={setTab}/>
-        </>
+        </View>
       }
     />
   );
@@ -186,15 +172,12 @@ const ProfileInfo = (props:ProfileInfoProps) => {
 
   const handleFollowersPress = () => {
     router.push('/(tabs)/profile/followers')
-    console.log("Followers button pressed.")
   };
   const handleFollowingPress = () => {
     router.push('/(tabs)/profile/following')
-    console.log("Following button pressed.")
   };
   const handleEditProfilePress = () => {
     router.push('/(tabs)/profile/editProfile')
-    console.log("Edit Profile button pressed.")
   };
 
   return (

--- a/mobile/bulingo/app/(tabs)/profile/index.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/index.tsx
@@ -45,13 +45,19 @@ type UserInfo = {
 };
 
 export type QuizInfo = {
+  author: {id: number, username: string},
+  average_score: number,
+  created_at: string,
   id: number,
   title: string,
   description: string,
-  author: string,
   level: string,
-  likes: number,
-  liked: boolean,
+  like_count: number,
+  is_liked: boolean,
+  is_bookmarked: boolean
+  question_count: number,
+  tags: string[],
+  times_taken: number,
 }
 
 export function isQuizInfo(object: any){
@@ -60,10 +66,7 @@ export function isQuizInfo(object: any){
     asQuizInfo.author !== undefined && 
     asQuizInfo.description !== undefined && 
     asQuizInfo.id !== undefined &&
-    asQuizInfo.level !== undefined && 
-    asQuizInfo.liked !== undefined && 
-    asQuizInfo.title !== undefined && 
-    asQuizInfo.likes !== undefined
+    asQuizInfo.level !== undefined
   );
 };
 
@@ -94,6 +97,7 @@ export default function Profile() {
       let updatedUserInfo;
 
       try {
+        console.log('here')
         const profileRequest = await TokenManager.authenticatedFetch(profileUrl, {
           method: 'GET',
           headers: {
@@ -114,6 +118,7 @@ export default function Profile() {
           },
         });
         const createdQuizResponse = await createdQuizRequest.json()
+        console.log(createdQuizResponse);
         if (createdQuizRequest.ok){
           updatedUserInfo = {...updatedUserInfo, createdQuizzes: createdQuizResponse}
         } else {
@@ -164,7 +169,8 @@ export default function Profile() {
       renderItem={({item}) => {
         if (isQuizInfo(item)){
           return (
-            <QuizCard {...item}/>
+            <QuizCard id={item.id} author={item.author.username} title={item.title} level={item.level} 
+              description={item.description} liked={item.is_liked} likes={item.like_count}/>
           );
         }
         else{

--- a/mobile/bulingo/app/(tabs)/profile/index.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/index.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, TouchableWithoutFeedback, Image, TouchableOpaci
 import { RFPercentage } from 'react-native-responsive-fontsize';
 import {router} from 'expo-router';
 import QuizCard from '@/app/components/quizCard';
+import TokenManager from '@/app/TokenManager';
 
 const debugUserInfo: UserInfo = {
   name: 'Yagiz Guldal',
@@ -81,22 +82,23 @@ export default function Profile() {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const ENDPOINT_URL = "http://161.35.208.249:8000/userInfo";  // Placeholder
     const fetchProfileInfo = async () => {
       const params = {
-        // TODO
+        'user': TokenManager.getUsername(),
        };
+       console.log(await TokenManager.getAccessToken());
       try {
-        const response = await fetch(ENDPOINT_URL, {
+        const response = await TokenManager.authenticatedFetch('profile/', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify(params),
         });
-
+        const res = await response.json();
+        console.log(res);
         if (response.ok){
-          setUserInfo(await response.json());
+          setUserInfo(res);
         } else {
           console.log(response.status)
         };

--- a/mobile/bulingo/app/(tabs)/profile/index.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/index.tsx
@@ -97,7 +97,6 @@ export default function Profile() {
       let updatedUserInfo;
 
       try {
-        console.log('here')
         const profileRequest = await TokenManager.authenticatedFetch(profileUrl, {
           method: 'GET',
           headers: {
@@ -118,7 +117,6 @@ export default function Profile() {
           },
         });
         const createdQuizResponse = await createdQuizRequest.json()
-        console.log(createdQuizResponse);
         if (createdQuizRequest.ok){
           updatedUserInfo = {...updatedUserInfo, createdQuizzes: createdQuizResponse}
         } else {

--- a/mobile/bulingo/app/(tabs)/profile/index.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/index.tsx
@@ -87,22 +87,35 @@ export default function Profile() {
 
       // Convert the parameters to a query string
       const queryString = new URLSearchParams(params).toString();
-      const urlWithParams = `${baseUrl}?${queryString}`;
+      const profileUrl = `${baseUrl}?${queryString}`;
+
+      const createdQuizUrl = `quiz/created/${username}/`;
 
       try {
-        const response = await TokenManager.authenticatedFetch(urlWithParams, {
+        const profileRequest = await TokenManager.authenticatedFetch(profileUrl, {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
           },
         });
-        const res = await response.json();
-        if (response.ok){
-          setUserInfo(res);
+        const profileResponse = await profileRequest.json();
+        if (profileRequest.ok){
+          setUserInfo(profileResponse);
         } else {
-          console.log(response.status)
+          console.log(profileRequest.status)
         };
-        setUserInfo
+        const createdQuizRequest = await TokenManager.authenticatedFetch(createdQuizUrl, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+        const createdQuizResponse = await createdQuizRequest.json()
+        if (createdQuizRequest.ok){
+          setUserInfo({...userInfo, createdQuizzes: createdQuizResponse});
+        } else {
+          console.log(createdQuizResponse.status)
+        };
       } catch (error) {
         console.error(error);
       }

--- a/mobile/bulingo/app/(tabs)/profile/likedQuizzes.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/likedQuizzes.tsx
@@ -2,37 +2,28 @@ import React, { useState, useEffect } from 'react';
 import {Text, StyleSheet, FlatList, View, TouchableWithoutFeedback, ActivityIndicator } from 'react-native';
 import QuizCard from '@/app/components/quizCard';
 import { QuizInfo } from '.';
+import TokenManager from '@/app/TokenManager';
 
 
 export default function Followers() {
   const [isLoading, setIsLoading] = useState(true);
-  const [likedQuizzes, setLikedQuizzes] = useState<QuizInfo[]>([
-    { id: 4, title: 'Plants', description: 'Test your plant knowledge', author: 'Halil', level: 'A2', likes: 300, liked: true },
-    { id: 5, title: 'Transport', description: 'Types of transport', author: 'Alex', level: 'B1', likes: 45, liked: true },
-    { id: 6, title: 'Food', description: 'Learn about foods', author: 'Oguz', level: 'A2', likes: 135, liked: true },
-    { id: 7, title: 'Animals', description: 'Our furry friends!', author: 'Aras', level: 'A2', likes: 12, liked: true },
-    { id: 8, title: 'Furniture', description: 'Essential furniture', author: 'Kaan', level: 'A2', likes: 3, liked: true },
-    { id: 9, title: 'Plants', description: 'Test your plant knowledge', author: 'Halil', level: 'A2', likes: 300, liked: true },
-    { id: 10, title: 'Transport', description: 'Types of transport', author: 'Alex', level: 'B1', likes: 45, liked: true },
-  ])
+  const [likedQuizzes, setLikedQuizzes] = useState<QuizInfo[]>([])
 
   useEffect(() => {
-    const ENDPOINT_URL = "http://161.35.208.249:8000/likedquizzes";  // Placeholder
+
     const fetchFollowers = async () => {
-      const params = {
-        // TODO
-       };
+      const url = 'quiz/likes';
       try {
-        const response = await fetch(ENDPOINT_URL, {
-          method: 'POST',
+        const response = await TokenManager.authenticatedFetch(url, {
+          method: 'GET',
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify(params),
         });
 
         if (response.ok){
-          setLikedQuizzes(await response.json());
+          const result = await response.json();
+          setLikedQuizzes(result);
         } else {
           console.log(response.status)
         };
@@ -63,7 +54,9 @@ export default function Followers() {
       data={likedQuizzes}
       renderItem={({item}) => { 
         return (
-          <QuizCard {...item} onLikePress={remove_from_liked(item.id)}/>
+          <QuizCard id={item.id} author={item.author.username} title={item.title} level={item.level} 
+              description={item.description} liked={item.is_liked} likes={item.like_count}
+              onLikePress={remove_from_liked(item.id)}/>
         );
       }}
       ListHeaderComponent={

--- a/mobile/bulingo/app/(tabs)/profile/userCard.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/userCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { TouchableOpacity, View, Image, StyleSheet, Text } from 'react-native';
 import { RFPercentage } from 'react-native-responsive-fontsize';
 import { router } from 'expo-router';
+import TokenManager from '@/app/TokenManager';
 
 type UserCardProps = {
   profilePictureUri: string,
@@ -15,7 +16,23 @@ type UserCardProps = {
 };
 
 const UserCard = (props: UserCardProps) => {
-  const handleButtonPress = () => {
+  const handleButtonPress = async () => {
+    const url = `profile/${props.buttonText.toLowerCase()}/`;
+    const params = {
+      'username': props.username,
+    }
+    try {
+      const response = await TokenManager.authenticatedFetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(params),
+      });
+      const res = await response.json()
+    } catch (error) {
+      console.error(error);
+    }
     console.log("Button Pressed: " + props.username);
     if (props.onButtonPress){
       props.onButtonPress();

--- a/mobile/bulingo/app/(tabs)/profile/userCard.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/userCard.tsx
@@ -39,7 +39,6 @@ const UserCard = (props: UserCardProps) => {
     }
   };
   const handleCardPress = () => {
-    console.log("Card Pressed: " + props.username)
     if (props.onCardPress){ 
       props.onCardPress();
     }

--- a/mobile/bulingo/app/(tabs)/profile/userCard.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/userCard.tsx
@@ -70,12 +70,22 @@ const UserCard = (props: UserCardProps) => {
   return (
     <TouchableOpacity style={styles.followerContainer} onPress={handleCardPress} testID='card'>
       <View style={styles.profilePictureContainer}>
-        <Image 
-          source={{
-            uri: props.profilePictureUri,
-          }} 
-          style={styles.profilePicture}
-        />
+        {props.profilePictureUri 
+          ? (
+            <Image 
+              source={{
+                uri: props.profilePictureUri,
+              }} 
+              style={styles.profilePicture}
+            />
+          )
+          : (
+            <Image 
+              source={require('@/assets/images/profile-icon.png')}
+              style={styles.profilePicture}
+            />
+          )}
+        
       </View>
       <View style={styles.usernameContainer}>
         <Text style={styles.usernameText}>{props.username}</Text>

--- a/mobile/bulingo/app/(tabs)/profile/users/[username].tsx
+++ b/mobile/bulingo/app/(tabs)/profile/users/[username].tsx
@@ -4,13 +4,14 @@ import { RFPercentage } from 'react-native-responsive-fontsize';
 import { router, useLocalSearchParams, useNavigation } from 'expo-router';
 import { QuizInfo, isQuizInfo } from '..';
 import QuizCard from '@/app/components/quizCard';
+import TokenManager from '@/app/TokenManager';
 
 const debugUserInfo: OtherUserInfo = {
   name: 'ygz2',
   about: "Hello, I am another user.",
   level: 'C2',
-  followerCount: 2,
-  followingCount: 5,
+  follower_count: 2,
+  following_count: 5,
   isFollowedByUser: false,
   isFollowingUser: true,
   createdQuizzes: [
@@ -37,8 +38,8 @@ type OtherUserInfo = {
   name: string,
   about: string,
   level: string,
-  followerCount: number,
-  followingCount: number,
+  follower_count: number,
+  following_count: number,
   isFollowingUser: boolean,
   isFollowedByUser: boolean,
   createdQuizzes: QuizInfo[], 
@@ -47,16 +48,6 @@ type OtherUserInfo = {
 };
 
 export default function Profile() {
-  /* 
-  Things we need to fetch for this page:
-  Send the access token, refresh token (maybe) and userId for this user. Get:
-   - Name
-   - Follower Count
-   - Following Count
-   - Created Quizzes
-   - Solved Quizzes
-   - Posts and Comments
-  */
   const navigation = useNavigation();
   const { username } = useLocalSearchParams();
   const [userInfo, setUserInfo] = useState<OtherUserInfo>(debugUserInfo);
@@ -67,15 +58,16 @@ export default function Profile() {
     navigation.setOptions({title: username});
     const fetchProfileInfo = async () => {
       const url = `profile/${username}/`;
+      console.log("url=", url)
       try {
-        const response = await fetch(url, {
+        const response = await TokenManager.authenticatedFetch(url, {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
           },
         });
         const res = await response.json()
-        console.log(res);
+        console.log('res=', res);
         if (response.ok){
           setUserInfo(res);
         } else {
@@ -129,8 +121,8 @@ export default function Profile() {
             name={userInfo.name}
             level={userInfo.level}
             about={userInfo.about}
-            followerCount={userInfo.followerCount}
-            followingCount={userInfo.followingCount}
+            followerCount={userInfo.follower_count}
+            followingCount={userInfo.following_count}
             isFollowedByUser={true}
           />
           <Tabs tab={tab} setTab={setTab}/>

--- a/mobile/bulingo/app/(tabs)/profile/users/[username].tsx
+++ b/mobile/bulingo/app/(tabs)/profile/users/[username].tsx
@@ -6,32 +6,17 @@ import { QuizInfo, isQuizInfo } from '..';
 import QuizCard from '@/app/components/quizCard';
 import TokenManager from '@/app/TokenManager';
 
-const debugUserInfo: OtherUserInfo = {
-  name: 'ygz2',
-  bio: "Hello, I am another user.",
-  level: 'C2',
-  follower_count: 2,
-  following_count: 5,
+const emptyUserInfo: OtherUserInfo = {
+  name: '',
+  bio: "",
+  level: 'NA',
+  follower_count: 0,
+  following_count: 0,
   is_followed: false,
-  isFollowingUser: true,
-  createdQuizzes: [
-    { id: 1, title: 'Food', description: 'Learn about foods', author: 'Oguz', level: 'A2', likes: 135, liked: true },
-    { id: 2, title: 'Animals', description: 'Our furry friends!', author: 'Aras', level: 'A2', likes: 12, liked: false },
-    { id: 3, title: 'Furniture', description: 'Essential furniture', author: 'Kaan', level: 'A2', likes: 3, liked: false },
-    { id: 4, title: 'Plants', description: 'Test your plant knowledge', author: 'Halil', level: 'A2', likes: 300, liked: false },
-    { id: 5, title: 'Transport', description: 'Types of transport', author: 'Alex', level: 'B1', likes: 45, liked: false },
-  ],  
-  solvedQuizzes: [
-    { id: 13, title: 'Furniture', description: 'Essential furniture', author: 'Kaan', level: 'A2', likes: 3, liked: false },
-    { id: 14, title: 'Plants', description: 'Test your plant knowledge', author: 'Halil', level: 'A2', likes: 300, liked: false },
-    { id: 15, title: 'Transport', description: 'Types of transport', author: 'Alex', level: 'B1', likes: 45, liked: false },
-    { id: 16, title: 'Food', description: 'Learn about foods', author: 'Oguz', level: 'A2', likes: 135, liked: false },
-    { id: 17, title: 'Animals', description: 'Our furry friends!', author: 'Aras', level: 'A2', likes: 12, liked: false },
-    { id: 18, title: 'Furniture', description: 'Essential furniture', author: 'Kaan', level: 'A2', likes: 3, liked: false },
-    { id: 19, title: 'Plants', description: 'Test your plant knowledge', author: 'Halil', level: 'A2', likes: 300, liked: false },
-    { id: 20, title: 'Transport', description: 'Types of transport', author: 'Alex', level: 'B1', likes: 45, liked: false},
-  ],
-  postsAndComments: [{id: 1, desc: 'Post 1'}, {id: 2, desc: 'Post 2'}],
+  createdQuizzes: [],  
+  solvedQuizzes: [],
+  posts: [],
+  comments: [],
 };
 
 type OtherUserInfo = {
@@ -40,17 +25,17 @@ type OtherUserInfo = {
   level: string,
   follower_count: number,
   following_count: number,
-  isFollowingUser: boolean,
   is_followed: boolean,
   createdQuizzes: QuizInfo[], 
   solvedQuizzes: QuizInfo[],
-  postsAndComments: {id: number, desc: string}[],  // Placeholder
+  posts: [],
+  comments: [],
 };
 
 export default function Profile() {
   const navigation = useNavigation();
   const { username } = useLocalSearchParams();
-  const [userInfo, setUserInfo] = useState<OtherUserInfo>(debugUserInfo);
+  const [userInfo, setUserInfo] = useState<OtherUserInfo>(emptyUserInfo);
   const [tab, setTab] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -85,7 +70,6 @@ export default function Profile() {
           },
         });
         const createdQuizResponse = await createdQuizRequest.json()
-        console.log("createdQuizResponse: ", createdQuizResponse)
         if (createdQuizRequest.ok){
           updatedUserInfo = {...updatedUserInfo, createdQuizzes: createdQuizResponse}
         } else {
@@ -98,12 +82,12 @@ export default function Profile() {
           },
         });
         const solvedQuizResponse = await solvedQuizRequest.json()
-        console.log("solvedQuizResponse: ", solvedQuizResponse)
         if (solvedQuizRequest.ok){
           setUserInfo({...updatedUserInfo, solvedQuizzes: solvedQuizResponse});
         } else {
           console.log(createdQuizResponse.status)
         };
+        console.log(updatedUserInfo);
         setUserInfo(updatedUserInfo);
       } catch (error) {
         console.error(error);
@@ -114,8 +98,7 @@ export default function Profile() {
     fetchProfileInfo();
   }, []);
 
-
-  const tabData: any = [userInfo.createdQuizzes, userInfo.solvedQuizzes, userInfo.postsAndComments]
+  const tabData = [userInfo.createdQuizzes, userInfo.solvedQuizzes, userInfo.posts.concat(userInfo.comments)]
 
   if(isLoading){
     return (
@@ -141,7 +124,7 @@ export default function Profile() {
         else{
           return (
             <View style={{height: 100, borderWidth: 3, borderColor: 'black', borderRadius: 15, justifyContent: 'center', alignItems: 'center', marginHorizontal: 15, marginVertical: 5,}}>
-              <Text>Placeholder Item {item.id}: {item.desc}</Text>
+              <Text>Placeholder Item</Text>
             </View>
           );
         }

--- a/mobile/bulingo/app/(tabs)/profile/users/[username].tsx
+++ b/mobile/bulingo/app/(tabs)/profile/users/[username].tsx
@@ -65,22 +65,19 @@ export default function Profile() {
 
   useEffect(() => {
     navigation.setOptions({title: username});
-    const ENDPOINT_URL = `http://161.35.208.249:8000/users/${username}`;  // Placeholder
     const fetchProfileInfo = async () => {
-      const params = {
-        // TODO
-       };
+      const url = `profile/${username}/`;
       try {
-        const response = await fetch(ENDPOINT_URL, {
-          method: 'POST',
+        const response = await fetch(url, {
+          method: 'GET',
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify(params),
         });
-
+        const res = await response.json()
+        console.log(res);
         if (response.ok){
-          setUserInfo(await response.json());
+          setUserInfo(res);
         } else {
           console.log(response.status)
         };

--- a/mobile/bulingo/app/(tabs)/profile/users/[username]/followers.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/users/[username]/followers.tsx
@@ -1,0 +1,113 @@
+import React, { useState, useEffect } from 'react';
+import {Text, StyleSheet, FlatList, View, Image, TouchableWithoutFeedback, ActivityIndicator } from 'react-native';
+import UserCard from '../../userCard';
+import TokenManager from '@/app/TokenManager';
+import { useLocalSearchParams, useNavigation } from 'expo-router';
+
+type UserInfoCompact = {
+  username: string,
+  name: string,
+  level: string,
+  profilePictureUri: string,
+};
+
+export default function Followers() {
+  const navigation = useNavigation();
+  const { username } = useLocalSearchParams();
+  const [isLoading, setIsLoading] = useState(true);
+  const [followers, setFollowers] = useState<UserInfoCompact[]>([
+    {username: 'oguz', name: 'Oguz', level: 'NA', profilePictureUri:"https://static.vecteezy.com/system/resources/thumbnails/024/646/930/small_2x/ai-generated-stray-cat-in-danger-background-animal-background-photo.jpg"},
+  ])
+
+  useEffect(() => {
+    navigation.setOptions({
+      title: `${username}'s Followers`, // Set the custom text here
+    });
+    const fetchFollowers = async () => {
+      const url = `profile/followers/${username}/`
+      try {
+        const response = await TokenManager.authenticatedFetch(url, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        if (response.ok){
+          const result = await response.json();
+          console.log("Followers:", result);
+          setFollowers(result);
+        } else {
+          console.log(response.status)
+        };
+      } catch (error) {
+        console.error(error);
+      }
+      setIsLoading(false);
+    };
+    fetchFollowers();
+  }, []);
+
+  if(isLoading){
+    return (
+      <TouchableWithoutFeedback>
+        <View style={styles.overlay}>
+          <ActivityIndicator size="large" color="#fff" />
+        </View>
+      </TouchableWithoutFeedback>
+    );
+  };
+
+  return (
+    <FlatList
+      data={followers}
+      keyExtractor={(item) => item.username}
+      renderItem={({item}) => {
+        return (
+          <UserCard 
+            name={item.name}
+            username={item.username} 
+            profilePictureUri={item.profilePictureUri} 
+            level={item.level}
+            buttonText={'Follow'}
+            buttonStyleNo={2}
+          />
+        );
+      }}
+      ListHeaderComponent={
+        <View style={styles.headerContainer}>
+          <Text style={styles.headerText}>Followers</Text>
+        </View>
+      }
+      style={styles.list}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  list: {
+    margin: 0,
+    padding: 5,
+  },
+  headerContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  headerText: {
+    fontSize: 30,
+    fontWeight: 'bold',
+  },
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 1,
+  },
+});
+

--- a/mobile/bulingo/app/(tabs)/profile/users/[username]/following.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/users/[username]/following.tsx
@@ -1,0 +1,114 @@
+import React, { useState, useEffect } from 'react';
+import {Text, StyleSheet, FlatList, View, Image, TouchableWithoutFeedback, ActivityIndicator } from 'react-native';
+import UserCard from '../../userCard';
+import TokenManager from '@/app/TokenManager';
+import { useLocalSearchParams, useNavigation } from 'expo-router';
+
+
+
+type UserInfoCompact = {
+  username: string,
+  name: string,
+  level: string,
+  profilePictureUri: string,
+  is_followed: boolean,
+};
+
+export default function Following() {
+  const navigation = useNavigation();
+  const { username } = useLocalSearchParams();
+  const [isLoading, setIsLoading] = useState(true);
+  const [following, setFollowing] = useState<UserInfoCompact[]>([])
+
+  useEffect(() => {
+    navigation.setOptions({
+      title: `${username}'s Following`, // Set the custom text here
+    });
+    const fetchFollowing = async () => {
+      const url = `profile/following/${username}/`
+
+      try {
+        const response = await TokenManager.authenticatedFetch(url, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        if (response.ok){
+          const result = await response.json()
+          setFollowing(result);
+        } else {
+          console.log(response.status)
+        };
+      } catch (error) {
+        console.error(error);
+      }
+      setIsLoading(false);
+    };
+    fetchFollowing();
+  }, []);
+
+  if(isLoading){
+    return (
+      <TouchableWithoutFeedback>
+        <View style={styles.overlay}>
+          <ActivityIndicator size="large" color="#fff" />
+        </View>
+      </TouchableWithoutFeedback>
+    );
+  };
+
+  return (
+    <FlatList
+      data={following}
+      keyExtractor={(item) => item.username}
+      renderItem={({item}) => {
+        return (
+          <UserCard 
+            name={item.name}
+            username={item.username} 
+            profilePictureUri={item.profilePictureUri} 
+            level={item.level}
+            buttonText={item.is_followed ? 'Unfollow' : 'Follow'}
+            buttonStyleNo={item.is_followed ? 1 : 2}
+          />
+        );
+      }}
+      ListHeaderComponent={
+        <View style={styles.headerContainer}>
+          <Text style={styles.headerText}>Following</Text>
+        </View>
+      }
+      style={styles.list}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  list: {
+    margin: 0,
+    padding: 5,
+  },
+  headerContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  headerText: {
+    fontSize: 30,
+    fontWeight: 'bold',
+  },
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 1,
+  },
+});
+

--- a/mobile/bulingo/app/(tabs)/profile/users/[username]/index.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/users/[username]/index.tsx
@@ -157,6 +157,8 @@ type ProfileInfoProps = {
 }
 
 const ProfileInfo = (props:ProfileInfoProps) => {
+  const [isFollowedByUser, setIsFollowedByUser] = useState(props.isFollowedByUser);
+  
   const handleFollowersPress = () => {
     router.push(`/(tabs)/profile/users/${props.username}/followers`)
     console.log("Followers button pressed.")
@@ -166,7 +168,7 @@ const ProfileInfo = (props:ProfileInfoProps) => {
     console.log("Following button pressed.")
   };
   const handleButtonPress = async () => {
-    const url = props.isFollowedByUser ? `profile/unfollow/`: "profile/follow/";
+    const url = isFollowedByUser ? `profile/unfollow/`: "profile/follow/";
     const params = {
       'username': props.username,
     }
@@ -179,6 +181,7 @@ const ProfileInfo = (props:ProfileInfoProps) => {
         body: JSON.stringify(params),
       });
       const res = await response.json()
+      setIsFollowedByUser(!isFollowedByUser)
     } catch (error) {
       console.error(error);
     }
@@ -213,7 +216,7 @@ const ProfileInfo = (props:ProfileInfoProps) => {
       </View>
       <View style={styles.profileInfoButtonContainer}>
         <TouchableOpacity style={styles.profileInfoButton} onPress={handleButtonPress}>
-          <Text style={styles.profileInfoButtonText}>{props.isFollowedByUser ? "Unfollow" : "Follow"}</Text>
+          <Text style={styles.profileInfoButtonText}>{isFollowedByUser ? "Unfollow" : "Follow"}</Text>
         </TouchableOpacity>
       </View>
     </View>

--- a/mobile/bulingo/app/(tabs)/profile/users/[username]/index.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/users/[username]/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, TouchableWithoutFeedback, Image, TouchableOpacity, FlatList, ActivityIndicator } from 'react-native';
 import { RFPercentage } from 'react-native-responsive-fontsize';
 import { router, useLocalSearchParams, useNavigation } from 'expo-router';
-import { QuizInfo, isQuizInfo } from '..';
+import { QuizInfo, isQuizInfo } from '../..';
 import QuizCard from '@/app/components/quizCard';
 import TokenManager from '@/app/TokenManager';
 
@@ -56,7 +56,6 @@ export default function Profile() {
           },
         });
         const res = await response.json()
-        console.log('res=', res);
         if (response.ok){
           updatedUserInfo = res
         } else {
@@ -87,7 +86,6 @@ export default function Profile() {
         } else {
           console.log(createdQuizResponse.status)
         };
-        console.log(updatedUserInfo);
         setUserInfo(updatedUserInfo);
       } catch (error) {
         console.error(error);
@@ -133,6 +131,7 @@ export default function Profile() {
       ListHeaderComponent={
         <>
           <ProfileInfo
+            username={username}
             name={userInfo.name}
             level={userInfo.level}
             about={userInfo.bio}
@@ -154,15 +153,16 @@ type ProfileInfoProps = {
   name: string,
   about: string,
   level: string,
+  username: string,
 }
 
 const ProfileInfo = (props:ProfileInfoProps) => {
   const handleFollowersPress = () => {
-    router.push('/(tabs)/profile/followers')
+    router.push(`/(tabs)/profile/users/${props.username}/followers`)
     console.log("Followers button pressed.")
   };
   const handleFollowingPress = () => {
-    router.push('/(tabs)/profile/following')
+    router.push(`/(tabs)/profile/users/${props.username}/following`)
     console.log("Following button pressed.")
   };
   const handleButtonPress = () => {

--- a/mobile/bulingo/app/(tabs)/profile/users/[username]/index.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/users/[username]/index.tsx
@@ -137,7 +137,7 @@ export default function Profile() {
             about={userInfo.bio}
             followerCount={userInfo.follower_count}
             followingCount={userInfo.following_count}
-            isFollowedByUser={true}
+            isFollowedByUser={userInfo.is_followed}
           />
           <Tabs tab={tab} setTab={setTab}/>
         </>
@@ -165,7 +165,24 @@ const ProfileInfo = (props:ProfileInfoProps) => {
     router.push(`/(tabs)/profile/users/${props.username}/following`)
     console.log("Following button pressed.")
   };
-  const handleButtonPress = () => {
+  const handleButtonPress = async () => {
+    const url = props.isFollowedByUser ? `profile/unfollow/`: "profile/follow/";
+    const params = {
+      'username': props.username,
+    }
+    try {
+      const response = await TokenManager.authenticatedFetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(params),
+      });
+      const res = await response.json()
+    } catch (error) {
+      console.error(error);
+    }
+    console.log("Button Pressed: " + props.username);
     console.log("Another user's follow/unfollow button pressed.")
   };
 

--- a/mobile/bulingo/app/(tabs)/quizzes/index.tsx
+++ b/mobile/bulingo/app/(tabs)/quizzes/index.tsx
@@ -4,7 +4,7 @@ import { router } from 'expo-router';
 import QuizCard from '@/app/components/quizCard';
 import TokenManager from '@/app/TokenManager';
 
-const BASE_URL = 'http://3.70.214.28:8000';
+const BASE_URL = 'http://54.93.52.38:8000';
 
 const QuizFeed = () => {
   const [quizzes, setQuizzes] = useState<any>([]);

--- a/mobile/bulingo/app/TokenManager.ts
+++ b/mobile/bulingo/app/TokenManager.ts
@@ -1,7 +1,7 @@
 import * as SecureStore from "expo-secure-store";
 
 
-const BASE_URL = "http://3.70.214.28:8000";
+const BASE_URL = "http://54.93.52.38:8000";
 
 class TokenManager {
   private username: string | null;
@@ -24,7 +24,7 @@ class TokenManager {
   
     if (!refreshToken) throw new Error("No refresh token found");
   
-    const response = await fetch("http://3.70.214.28:8000/refresh", {
+    const response = await fetch("http://54.93.52.38:8000/refresh", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -75,7 +75,7 @@ class TokenManager {
     }
   
     const fetchWithToken = async (token: string) => {
-      return await fetch(`${BASE_URL}${endpoint}`, {
+      return await fetch(`${BASE_URL}/${endpoint}`, {
         ...options,
         headers: {
           ...options.headers,

--- a/mobile/bulingo/app/components/topNotification.tsx
+++ b/mobile/bulingo/app/components/topNotification.tsx
@@ -5,9 +5,10 @@ type NotificationProps = {
     message: string;
     duration?: number; // Duration in milliseconds (default: 3000ms)
     onHide?: () => void; // Callback when notification hides
+    color?: string,
 };
 
-const Notification: React.FC<NotificationProps> = ({ message, duration = 3000, onHide }) => {
+const Notification: React.FC<NotificationProps> = ({ message, duration = 3000, onHide, color }) => {
     const [fadeAnim] = useState(new Animated.Value(0)); // Animation value
 
     useEffect(() => {
@@ -33,7 +34,7 @@ const Notification: React.FC<NotificationProps> = ({ message, duration = 3000, o
     }, [fadeAnim, duration, onHide]);
 
     return (
-        <Animated.View style={[styles.notification, { opacity: fadeAnim }]}>
+        <Animated.View style={[styles.notification, { opacity: fadeAnim }, color && {backgroundColor: color}]}>
             <Text style={styles.notificationText}>{message}</Text>
         </Animated.View>
     );

--- a/mobile/bulingo/app/components/topNotification.tsx
+++ b/mobile/bulingo/app/components/topNotification.tsx
@@ -1,0 +1,61 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, StyleSheet, Animated } from 'react-native';
+
+type NotificationProps = {
+    message: string;
+    duration?: number; // Duration in milliseconds (default: 3000ms)
+    onHide?: () => void; // Callback when notification hides
+};
+
+const Notification: React.FC<NotificationProps> = ({ message, duration = 3000, onHide }) => {
+    const [fadeAnim] = useState(new Animated.Value(0)); // Animation value
+
+    useEffect(() => {
+        // Fade in the notification
+        Animated.timing(fadeAnim, {
+            toValue: 1,
+            duration: 300,
+            useNativeDriver: true,
+        }).start();
+
+        // Automatically hide the notification after the specified duration
+        const timer = setTimeout(() => {
+            Animated.timing(fadeAnim, {
+                toValue: 0,
+                duration: 300,
+                useNativeDriver: true,
+            }).start(() => {
+                if (onHide) onHide(); // Call onHide callback if provided
+            });
+        }, duration);
+
+        return () => clearTimeout(timer); // Cleanup timer on unmount
+    }, [fadeAnim, duration, onHide]);
+
+    return (
+        <Animated.View style={[styles.notification, { opacity: fadeAnim }]}>
+            <Text style={styles.notificationText}>{message}</Text>
+        </Animated.View>
+    );
+};
+
+const styles = StyleSheet.create({
+    notification: {
+        position: 'absolute',
+        top: 50,
+        left: 10,
+        right: 10,
+        backgroundColor: '#4caf50',
+        padding: 10,
+        borderRadius: 5,
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000, // Ensure it stays above other UI elements
+    },
+    notificationText: {
+        color: 'white',
+        fontWeight: 'bold',
+    },
+});
+
+export default Notification;

--- a/mobile/bulingo/app/login.tsx
+++ b/mobile/bulingo/app/login.tsx
@@ -11,6 +11,7 @@ export default function Home() {
   const [password, setPassword] = useState('');  // State for password
   const [isLoading, setIsLoading] = useState(false);
   const [isErrorVisible, setIsErrorVisible] = useState(false);
+  
   const handleRegister = () => {
     router.navigate('/register')
   };

--- a/mobile/bulingo/app/login.tsx
+++ b/mobile/bulingo/app/login.tsx
@@ -2,6 +2,8 @@ import React, {useState, createContext, useContext} from 'react';
 import {Pressable, StyleSheet, Text, View, TextInput, TouchableWithoutFeedback, ActivityIndicator} from 'react-native';
 import {router} from 'expo-router'
 import TokenManager from './TokenManager'; // Import the TokenManager
+import Notification from './components/topNotification';
+
 
 
 const LOGIN_URL = "http://54.93.52.38:8000/login/";
@@ -11,6 +13,8 @@ export default function Home() {
   const [password, setPassword] = useState('');  // State for password
   const [isLoading, setIsLoading] = useState(false);
   const [isErrorVisible, setIsErrorVisible] = useState(false);
+  const [notification, setNotification] = useState<string | null>(null);
+
   
   const handleRegister = () => {
     router.navigate('/register')
@@ -38,6 +42,7 @@ export default function Home() {
         TokenManager.setUsername(username);
         router.replace('/?notification=login_success');
       } else {
+        setNotification("Incorrect Login information.")
         setIsErrorVisible(true);
       };
     } catch (error) {
@@ -55,6 +60,14 @@ export default function Home() {
             <ActivityIndicator size="large" color="#fff" />
           </View>
         </TouchableWithoutFeedback>
+      )}
+
+      {notification && (
+          <Notification
+              message={notification}
+              onHide={() => setNotification(null)} // Clear notification after hiding
+              color='red'
+          />
       )}
 
         <View style={styles.page}>

--- a/mobile/bulingo/app/login.tsx
+++ b/mobile/bulingo/app/login.tsx
@@ -36,7 +36,7 @@ export default function Home() {
         const { access, refresh } = json;
         TokenManager.saveTokens(access, refresh);
         TokenManager.setUsername(username);
-        router.replace('/');
+        router.replace('/?notification=login_success');
       } else {
         setIsErrorVisible(true);
       };

--- a/mobile/bulingo/app/login.tsx
+++ b/mobile/bulingo/app/login.tsx
@@ -4,7 +4,7 @@ import {router} from 'expo-router'
 import TokenManager from './TokenManager'; // Import the TokenManager
 
 
-const LOGIN_URL = "http://3.70.214.28:8000/login/";
+const LOGIN_URL = "http://54.93.52.38:8000/login/";
 
 export default function Home() {
   const [username, setUsername] = useState('');    // State for username

--- a/mobile/bulingo/app/register.tsx
+++ b/mobile/bulingo/app/register.tsx
@@ -48,6 +48,7 @@ const Register = () => {
       'password': password,
       'email': email,
     };
+    console.log(params);
     try {
       const response = await fetch(SIGNUP_URL, {
         method: 'POST',

--- a/mobile/bulingo/app/register.tsx
+++ b/mobile/bulingo/app/register.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, TextInput, TouchableOpacity, Image, StyleSheet, TouchableWithoutFeedback, Keyboard } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
-import { useNavigation } from '@react-navigation/native';
 import {router} from 'expo-router';
 
 const SIGNUP_URL = "http://54.93.52.38:8000/signup/";
@@ -60,7 +59,7 @@ const Register = () => {
       const json = await response.json();
       console.log(json)
       if (json){
-        router.navigate('/');
+        router.navigate('/?notification=register_success');
       }
     } catch (error) {
       console.error(error);

--- a/mobile/bulingo/app/register.tsx
+++ b/mobile/bulingo/app/register.tsx
@@ -4,7 +4,7 @@ import { Picker } from '@react-native-picker/picker';
 import { useNavigation } from '@react-navigation/native';
 import {router} from 'expo-router';
 
-const SIGNUP_URL = "http://3.70.214.28:8000/signup/";
+const SIGNUP_URL = "http://54.93.52.38:8000/signup/";
 
 const Register = () => {
   const [email, setEmail] = useState('');

--- a/mobile/bulingo/package-lock.json
+++ b/mobile/bulingo/package-lock.json
@@ -10875,6 +10875,7 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-14.0.0.tgz",
       "integrity": "sha512-VyhtRFXP+7hQmHhKlHIOWid1Q/IRpM7Uif32tZHLZHvQ6FNz2cUkr26XWGvCa7btYbrR6OL++FBFZYjbIcRZTw==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*"
       }


### PR DESCRIPTION
Fixes #648
This PR includes the changes from #654, and therefore SHOULD NOT BE MERGED BEFORE PR #654 IS MERGED!

The solution I came up with is relatively simple, instead of finding every single point where something related to the profile changes, I refresh the profile page whenever it is navigated to so it always has the latest data. This is a slower approach but it is more precise and error-proof.