### PR TITLE
fix(mobile): fix reference error in tests

### DIFF
--- a/mobile/bulingo/__tests__/commentcard.test.tsx
+++ b/mobile/bulingo/__tests__/commentcard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import CommentCard from './commentcard';
+import CommentCard from '../app/components/commentcard';
 
 test('renders the commentcard and handles press', () => {
   const mockFn = jest.fn();

--- a/mobile/bulingo/__tests__/postcard.test.tsx
+++ b/mobile/bulingo/__tests__/postcard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import PostCard from './postcard';
+import PostCard from '../app/components/postcard';
 
 test('renders the post card and handles presses', () => {
   const mockFn1 = jest.fn();

--- a/mobile/bulingo/__tests__/quizCard.test.tsx
+++ b/mobile/bulingo/__tests__/quizCard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import QuizCard from './quizCard';
+import QuizCard from '../app/components/quizCard';
 
 test('renders the quiz card and handles presses', () => {
   const mockFn1 = jest.fn();

--- a/mobile/bulingo/__tests__/userCard.test.tsx
+++ b/mobile/bulingo/__tests__/userCard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import UserCard from './userCard';
+import UserCard from '../app/(tabs)/profile/userCard';
 
 test('renders the user card and handles presses', () => {
   const mockFn1 = jest.fn();


### PR DESCRIPTION
Fixes #668.
This PR includes the most straight-forward solution to the error we were encountering. When the tests were included in the app folder, they were always being viewed as different components and they always lead to errors. This PR moves the tests to a new '\_\_tests__' directory. The tests all pass (you can try with `npm test`), and the code works successfully without throwing errors at the start.

I have tried many other methods to fix this issue, such as changing jest config, installing new react versions or new libraries, but this is the only one that worked.