### PR TITLE
Let admins delete comments of everyone (BACKEND)

### DIFF
--- a/backend/app/views_directory/comments.py
+++ b/backend/app/views_directory/comments.py
@@ -45,7 +45,7 @@ def delete_comment(request):
     if not comment_id:
         return Response({"detail": "comment_id is required."}, status=status.HTTP_400_BAD_REQUEST)
 
-    comment = get_object_or_404(Comment, id=comment_id, author=request.user)
+    comment = get_object_or_404(Comment, id=comment_id)
     user = request.user
     if comment.author != user and not user.is_staff:
         return Response({"detail": "You do not have permission to delete this comment."}, status=status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
Fixes #794
This is an extremely simple PR, just removing the check for the author being the DELETE request sender when an admin tries to delete the comments of anyone.