### PR TITLE
Fix ModalDictionary not displaying Bookmark info correctly (Mobile)

### DIFF
--- a/mobile/bulingo/app/components/modalDictionary.tsx
+++ b/mobile/bulingo/app/components/modalDictionary.tsx
@@ -56,6 +56,28 @@ export default function ModalDictionary(props: ModalDictionaryProps){
       } catch (error) {
         console.error(error);
       }
+
+      if(TokenManager.getUsername()){  // Only if the user is logged in
+        const url = "word/bookmarks/"  // Placeholder
+        try {
+          const response = await TokenManager.authenticatedFetch(url, {
+            method: 'GET',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          });
+
+          if (response.ok){
+            const result = await response.json()
+            setIsWordBookmarked(result.bookmarked_words.includes(getCorrectForm(props.word))); 
+          } else {
+            console.log(response.status)
+          };
+        } catch (error) {
+          console.error(error);
+        }
+      }
+
       setIsLoading(false);
     };
     


### PR DESCRIPTION
Fixes #832.

This is a really simple bug fix PR. The change is that now, the ModalDictionary component fetches the bookmarked words of the currently logged in user and checks if the currently displayed word is among them to change the look and function of the bookmark button.