### PR TITLE
Guest Views for Notifications, Profile, and Search Pages & Components (Mobile)

### DIFF
--- a/mobile/bulingo/app/(tabs)/profile/index.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/index.tsx
@@ -4,6 +4,7 @@ import { RFPercentage } from 'react-native-responsive-fontsize';
 import {router, useFocusEffect} from 'expo-router';
 import QuizCard from '@/app/components/quizCard';
 import TokenManager from '@/app/TokenManager';
+import GuestModal from '@/app/components/guestModal';
 
 const defaultUserInfo: UserInfo = {
   username: 'ygz',
@@ -61,20 +62,19 @@ export default function Profile() {
   const [userInfo, setUserInfo] = useState<UserInfo>(defaultUserInfo);
   const [tab, setTab] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
+  const [guestModalVisible, setGuestModalVisible] = useState(false);
 
   useFocusEffect(
     useCallback(() => {
-      console.log('Page is focused!');
-
-      // Trigger your re-fetching or re-rendering logic here.
-      // For example, fetch new data:
       const fetchProfileInfo = async () => {
         setIsLoading(true);
         const username = TokenManager.getUsername()
-        if (username === null){
-          console.error("username is null")
+        if (!username){
+          setGuestModalVisible(true);
+          setIsLoading(false);
           return
         }
+        setGuestModalVisible(false);
         const params = {
           'user': username,
          };
@@ -139,7 +139,6 @@ export default function Profile() {
 
       // Optional cleanup (runs when page loses focus)
       return () => {
-        console.log('Page is no longer focused.');
       };
     }, [])
   );
@@ -155,6 +154,14 @@ export default function Profile() {
       </TouchableWithoutFeedback>
     );
   };
+
+  const onGuestModalClose = () => {
+    setGuestModalVisible(false);
+    router.replace("/");
+  }
+  if(guestModalVisible){
+    return <GuestModal onClose={onGuestModalClose}/>
+  }
 
   return (
     <FlatList 

--- a/mobile/bulingo/app/(tabs)/profile/userCard.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/userCard.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { TouchableOpacity, View, Image, StyleSheet, Text } from 'react-native';
 import { RFPercentage } from 'react-native-responsive-fontsize';
 import { router } from 'expo-router';
 import TokenManager from '@/app/TokenManager';
+import GuestModal from '@/app/components/guestModal';
 
 type UserCardProps = {
   profilePictureUri: string,
@@ -16,7 +17,14 @@ type UserCardProps = {
 };
 
 const UserCard = (props: UserCardProps) => {
+  const [guestModalVisible, setGuestModalVisible] = useState(false);
+
   const handleButtonPress = async () => {
+    if(!TokenManager.getUsername()){
+      setGuestModalVisible(true);
+      return
+    }
+
     const url = `profile/${props.buttonText.toLowerCase()}/`;
     const params = {
       'username': props.username,
@@ -38,6 +46,11 @@ const UserCard = (props: UserCardProps) => {
     }
   };
   const handleCardPress = () => {
+    if(!TokenManager.getUsername()){
+      setGuestModalVisible(true);
+      return;
+    }
+
     if (props.onCardPress){ 
       props.onCardPress();
     }
@@ -70,40 +83,43 @@ const UserCard = (props: UserCardProps) => {
   
 
   return (
-    <TouchableOpacity style={styles.followerContainer} onPress={handleCardPress} testID='card'>
-      <View style={styles.profilePictureContainer}>
-        {props.profilePictureUri 
-          ? (
-            <Image 
-              source={{
-                uri: props.profilePictureUri,
-              }} 
-              style={styles.profilePicture}
-            />
-          )
-          : (
-            <Image 
-              source={require('@/assets/images/profile-icon.png')}
-              style={styles.profilePicture}
-            />
-          )}
-      </View>
-      <View style={styles.usernameContainer}>
-        <Text style={styles.usernameText}>{props.username.length <= 12 ? props.username : `${props.username.slice(0, 10)}..`}</Text>
-      </View>
-      <View style={styles.followerContainerRightCompartment}>
-        <View style={styles.levelContainer}>
-          <Text style={styles.levelText}>{props.level}</Text>
+    <>
+      {guestModalVisible && <GuestModal onClose={() => setGuestModalVisible(false)}/>}
+      <TouchableOpacity style={styles.followerContainer} onPress={handleCardPress} testID='card'>
+        <View style={styles.profilePictureContainer}>
+          {props.profilePictureUri 
+            ? (
+              <Image 
+                source={{
+                  uri: props.profilePictureUri,
+                }} 
+                style={styles.profilePicture}
+              />
+            )
+            : (
+              <Image 
+                source={require('@/assets/images/profile-icon.png')}
+                style={styles.profilePicture}
+              />
+            )}
         </View>
-        { props.buttonStyleNo != 3 &&
-          <View style={styles.buttonContainer}>
-            <TouchableOpacity style={[styles.buttonStyle, buttonStyleAddOn]} onPress={handleButtonPress} testID='button'>
-              <Text style={[styles.buttonText, {color: buttonTextColor}]}>{props.buttonText}</Text>
-            </TouchableOpacity>
+        <View style={styles.usernameContainer}>
+          <Text style={styles.usernameText}>{props.username.length <= 12 ? props.username : `${props.username.slice(0, 10)}..`}</Text>
+        </View>
+        <View style={styles.followerContainerRightCompartment}>
+          <View style={styles.levelContainer}>
+            <Text style={styles.levelText}>{props.level}</Text>
           </View>
-        }
-      </View>
-    </TouchableOpacity>
+          { props.buttonStyleNo != 3 &&
+            <View style={styles.buttonContainer}>
+              <TouchableOpacity style={[styles.buttonStyle, buttonStyleAddOn]} onPress={handleButtonPress} testID='button'>
+                <Text style={[styles.buttonText, {color: buttonTextColor}]}>{props.buttonText}</Text>
+              </TouchableOpacity>
+            </View>
+          }
+        </View>
+      </TouchableOpacity>
+    </>
   );
 };
 

--- a/mobile/bulingo/app/(tabs)/search.tsx
+++ b/mobile/bulingo/app/(tabs)/search.tsx
@@ -4,16 +4,10 @@ import { RFPercentage } from 'react-native-responsive-fontsize';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import QuizCard from '../components/quizCard';
 import UserCard from './profile/userCard';
-import TokenManager from '../TokenManager';
+import TokenManager, { BASE_URL } from '../TokenManager';
 import PostCard from '../components/postcard';
 import CommentCard from '../components/commentcard';
 
-const MOCK_SEARCH_RESULT = [
-  {type: "quiz", data: { id: 13, title: 'Furniture', description: 'Essential furniture', author: 'Kaan', level: 'A2', likes: 3, liked: false }},
-  {type: "user", data: { id: 18, username: 'ygz2', name: 'Yagiz Guldal', level: 'A1', profilePictureUri:"https://static.vecteezy.com/system/resources/thumbnails/024/646/930/small_2x/ai-generated-stray-cat-in-danger-background-animal-background-photo.jpg"}},
-  {type: "post", data: { id: 36, name: "Placeholder Post"}},
-  {type: "comment", data: { id: 326, name: "Placeholder Comment"}},
-];
 
 export default function Tab() {
   const [searchResults, setSearchResults] = useState<any>(undefined);
@@ -33,7 +27,7 @@ export default function Tab() {
     setIsLoading(true);
     const url = `search/?q=${userInput}&t=${option.toLowerCase()}`
     try {
-      const response = await TokenManager.authenticatedFetch(url, {
+      const response = await fetch(BASE_URL + "/" + url, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',

--- a/mobile/bulingo/app/TokenManager.ts
+++ b/mobile/bulingo/app/TokenManager.ts
@@ -1,7 +1,7 @@
 import * as SecureStore from "expo-secure-store";
 
 
-const BASE_URL = "http://64.226.76.231:8000";
+export const BASE_URL = "http://64.226.76.231:8000";
 
 class TokenManager {
   private username: string | null;

--- a/mobile/bulingo/app/components/commentcard.tsx
+++ b/mobile/bulingo/app/components/commentcard.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native';
 import { FontAwesome } from '@expo/vector-icons';
+import GuestModal from './guestModal';
+import TokenManager from '../TokenManager';
 
 interface CommentCardProps {
     id: number;
@@ -10,20 +12,38 @@ interface CommentCardProps {
     comment: string;
     liked: boolean;
     likes: number;
-
 }
 
 const CommentCard: React.FC<CommentCardProps> = ({ id, isBookmarked: initialBookmark, username, comment, onUpvote, liked, likes }) => {
     const [isBookmarked, setIsBookmarked] = useState(initialBookmark);
+    const [guestModalVisible, setGuestModalVisible] = useState(false);
+
 
     const toggleBookmark = () => {
         setIsBookmarked(!isBookmarked);
     };
 
+    const handleLikePress = () => {
+        if(!TokenManager.getUsername()){
+            setGuestModalVisible(true);
+            return;
+        }
+        onUpvote(id);
+    }
+    
+    const handleBookmarkPress = () => {
+        if(!TokenManager.getUsername()){
+            setGuestModalVisible(true);
+            return;
+        }
+        // TODO: Implement bookmark here!
+        toggleBookmark();
+    }
 
 
     return (
         <>
+        {guestModalVisible && <GuestModal onClose={() => setGuestModalVisible(false)}/>}
         <View style={styles.cardContainer}>
            
            
@@ -47,7 +67,7 @@ const CommentCard: React.FC<CommentCardProps> = ({ id, isBookmarked: initialBook
                     </TouchableOpacity>
                     <Text style={styles.upvoteCount}>{upvoteCount}</Text> */}
 
-            <TouchableOpacity style={styles.likeButton} onPress={() => onUpvote(id)} testID='likeButton'>
+            <TouchableOpacity style={styles.likeButton} onPress={handleLikePress} testID='likeButton'>
                         <Text style={styles.quizLikes}>
                         <Image source={liked ? require('../../assets/images/like-2.png') : require('../../assets/images/like-1.png')}style={styles.icon} /> 
                                           {/* <Image source={ require('../../assets/images/like-2.png')}style={styles.icon} />  */}
@@ -59,7 +79,7 @@ const CommentCard: React.FC<CommentCardProps> = ({ id, isBookmarked: initialBook
 
 
                 {/* Bookmark Button */}
-                <TouchableOpacity onPress={toggleBookmark} style={styles.bookmarkButton}>
+                <TouchableOpacity onPress={handleBookmarkPress} style={styles.bookmarkButton}>
                     <FontAwesome name={isBookmarked ? 'bookmark' : 'bookmark-o'} size={20} color="black" />
                 </TouchableOpacity>
             </View>

--- a/mobile/bulingo/app/components/guestModal.tsx
+++ b/mobile/bulingo/app/components/guestModal.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Text, View, StyleSheet, Modal, TouchableOpacity, Pressable } from 'react-native';
+import { router } from 'expo-router';
+
+type GuestModalProps = {
+  onClose: () => void;
+}
+
+export default function GuestModal(props: GuestModalProps){
+  const onLoginPress = () => {
+    router.navigate("/login");
+  }
+
+  const onRegisterPress = () => {
+    router.navigate("/register");
+  }
+
+  return (
+    <Modal
+      // animationType="slide"
+      transparent={true}
+      onRequestClose={props.onClose}
+    >
+      <Pressable style={styles.modalBackground} onPress={props.onClose}>
+        <Pressable style={styles.modalContent}>
+          <Text style={styles.text}>You need to be logged in to perform this action. Please login, or register if you don't have an account.</Text>
+          <TouchableOpacity onPress={onLoginPress} style={styles.button}>
+            <Text style={styles.buttonText}>Login</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={onRegisterPress} style={styles.button}>
+            <Text style={styles.buttonText}>Register</Text>
+          </TouchableOpacity>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create(
+  {
+    modalBackground: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    },
+    modalContent: {
+      width: '80%',
+      maxHeight: '60%',
+      backgroundColor: 'white',
+      padding: 20,
+      borderRadius: 10,
+      alignItems: 'center',
+    },
+    button: {
+      borderRadius: 15,
+      width: "80%",
+      height: 50,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginVertical: 5,
+      backgroundColor: "#3944FD",
+    },
+    buttonText: {
+      fontSize: 22,
+      color: 'white',
+      textAlign: 'center',
+    },
+    text: {
+      textAlign: 'center',
+      fontSize: 18,
+      marginBottom: 20,
+    },
+});

--- a/mobile/bulingo/app/components/guestModal.tsx
+++ b/mobile/bulingo/app/components/guestModal.tsx
@@ -8,11 +8,11 @@ type GuestModalProps = {
 
 export default function GuestModal(props: GuestModalProps){
   const onLoginPress = () => {
-    router.navigate("/login");
+    router.replace("/login");
   }
 
   const onRegisterPress = () => {
-    router.navigate("/register");
+    router.replace("/register");
   }
 
   return (

--- a/mobile/bulingo/app/components/postcard.tsx
+++ b/mobile/bulingo/app/components/postcard.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native';
 import { FontAwesome } from '@expo/vector-icons';
+import GuestModal from './guestModal';
+import TokenManager from '../TokenManager';
 
 interface PostCardProps {
     id: string;
@@ -11,7 +13,7 @@ interface PostCardProps {
   liked: boolean;
   isBookmarked: boolean;
   feedOrPost: string;
-  onUpvote: () => void;
+  onUpvote: (id:any) => void;
   onBookmark: () => void;
   onPress?: () => void;
 }
@@ -30,47 +32,66 @@ const PostCard: React.FC<PostCardProps> = ({
   onBookmark,
   onPress,
 }) => {
+  const [guestModalVisible, setGuestModalVisible] = useState(false);
 
+  const handleLikePress = () => {
+    if(!TokenManager.getUsername()){
+      setGuestModalVisible(true);
+      return;
+    }
+    onUpvote(id);
+  }
+
+  const handleBookmarkPress = () => {
+    if(!TokenManager.getUsername()){
+      setGuestModalVisible(true);
+      return;
+    }
+    onBookmark();
+  }
 
   return (
-    <TouchableOpacity onPress={onPress} testID='card'>
-      <View style={styles.cardContainer}>
-        <View style={styles.header}>
-          <Text style={styles.title}>{title}</Text>
-          <Text style={styles.author}>by {author}</Text>
-        </View>
-        <View style={styles.tagsContainer}>
-          {tags && tags.map((tag, index) => (
-            <View key={index} style={styles.levelBadge}>
-              <Text style={styles.levelText}>{tag}</Text>
-            </View>
-          ))}
-        </View>
-        <View style={styles.footer}>
-          <View style={styles.actionsContainer}>
-            {/* <TouchableOpacity onPress={onUpvote} style={styles.upvoteButton}>
-              <FontAwesome name="arrow-up" size={20} color="green" />
-              <Text style={styles.upvoteCount}>{likes}</Text>
-            </TouchableOpacity>
-             */}
-            <TouchableOpacity style={styles.likeButton} onPress={() => onUpvote(id)} testID={'likeButton'}>
-             <Text style={styles.quizLikes}>
-            <Image source={liked ? require('../../assets/images/like-2.png') : require('../../assets/images/like-1.png')}style={styles.icon} /> 
-            {likes}
-            </Text>
-            </TouchableOpacity>
+    <>
+      {guestModalVisible && <GuestModal onClose={() => setGuestModalVisible(false)}/>}
+      <TouchableOpacity onPress={onPress} testID='card'>
+        <View style={styles.cardContainer}>
+          <View style={styles.header}>
+            <Text style={styles.title}>{title}</Text>
+            <Text style={styles.author}>by {author}</Text>
+          </View>
+          <View style={styles.tagsContainer}>
+            {tags && tags.map((tag, index) => (
+              <View key={index} style={styles.levelBadge}>
+                <Text style={styles.levelText}>{tag}</Text>
+              </View>
+            ))}
+          </View>
+          <View style={styles.footer}>
+            <View style={styles.actionsContainer}>
+              {/* <TouchableOpacity onPress={onUpvote} style={styles.upvoteButton}>
+                <FontAwesome name="arrow-up" size={20} color="green" />
+                <Text style={styles.upvoteCount}>{likes}</Text>
+              </TouchableOpacity>
+              */}
+              <TouchableOpacity style={styles.likeButton} onPress={handleLikePress} testID={'likeButton'}>
+              <Text style={styles.quizLikes}>
+              <Image source={liked ? require('../../assets/images/like-2.png') : require('../../assets/images/like-1.png')}style={styles.icon} /> 
+              {likes}
+              </Text>
+              </TouchableOpacity>
 
-            <TouchableOpacity onPress={onBookmark} style={styles.bookmarkButton} testID={'bookmarkButton'}>
-              <FontAwesome 
-                name={isBookmarked ? 'bookmark' : 'bookmark-o'} 
-                size={20} 
-                color="black" 
-              />
-            </TouchableOpacity>
+              <TouchableOpacity onPress={handleBookmarkPress} style={styles.bookmarkButton} testID={'bookmarkButton'}>
+                <FontAwesome 
+                  name={isBookmarked ? 'bookmark' : 'bookmark-o'} 
+                  size={20} 
+                  color="black" 
+                />
+              </TouchableOpacity>
+            </View>
           </View>
         </View>
-      </View>
-    </TouchableOpacity>
+      </TouchableOpacity>
+    </>
   );
 };
 

--- a/mobile/bulingo/app/components/quizCard.tsx
+++ b/mobile/bulingo/app/components/quizCard.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { TouchableOpacity, Image, Text, View, StyleSheet, useColorScheme } from 'react-native';
+import GuestModal from './guestModal';
+import TokenManager from '../TokenManager';
 
 type QuizCardProps = {
   title: string,
@@ -18,6 +20,7 @@ type QuizCardProps = {
 export default function QuizCard(props: QuizCardProps){
   const [likes, setLikes] = useState(props.likes);
   const [liked, setLiked] = useState(props.liked);
+  const [guestModalVisible, setGuestModalVisible] = useState(false);
 
   const colorScheme = useColorScheme();
   const styles = getStyles(colorScheme);
@@ -28,6 +31,11 @@ export default function QuizCard(props: QuizCardProps){
   };
 
   const handleLikePress = (id: number) => {
+    if(!TokenManager.getUsername()){
+      setGuestModalVisible(true);
+      return
+    }
+
     props.onLikePress && props.onLikePress(id);
     if(liked){
       setLiked(false);
@@ -40,36 +48,43 @@ export default function QuizCard(props: QuizCardProps){
   };
 
   const handleBookmarkPress = (id: number) => {
+    if(!TokenManager.getUsername()){
+      setGuestModalVisible(true);
+      return
+    }
     props.onBookmarkPress && props.onBookmarkPress(id);
   };
 
   return (
-    <TouchableOpacity
-      style={[styles.quizItem, styles.elevation]}
-      onPress={() => handleQuizPress(props.id)}
-      testID='quiz'
-    >
-      <View style={styles.quizTop}>
-        <Text style={styles.quizTitle}>{props.title}</Text>
-        <Text style={styles.quizDescription}>{props.description}</Text>
-      </View>
-      <View style={styles.quizBottom}>
-        <View style={styles.quizBottomLeft}>
-          <Text style={styles.quizAuthor}>by {props.author}</Text>
-          <Text style={styles.quizLevel}>{props.level}</Text>
+    <>
+      {guestModalVisible && <GuestModal onClose={() => setGuestModalVisible(false)}/>}
+      <TouchableOpacity
+        style={[styles.quizItem, styles.elevation]}
+        onPress={() => handleQuizPress(props.id)}
+        testID='quiz'
+      >
+        <View style={styles.quizTop}>
+          <Text style={styles.quizTitle}>{props.title}</Text>
+          <Text style={styles.quizDescription}>{props.description}</Text>
         </View>
-        <TouchableOpacity style={styles.likeButton} onPress={() => handleLikePress(props.id)} testID='likeButton'>
-          <Text style={styles.quizLikes}>
-          <Image source={liked ? require('@/assets/images/like-2.png') : require('@/assets/images/like-1.png')}style={styles.icon} /> {likes}
-          </Text>
-        </TouchableOpacity>
+        <View style={styles.quizBottom}>
+          <View style={styles.quizBottomLeft}>
+            <Text style={styles.quizAuthor}>by {props.author}</Text>
+            <Text style={styles.quizLevel}>{props.level}</Text>
+          </View>
+          <TouchableOpacity style={styles.likeButton} onPress={() => handleLikePress(props.id)} testID='likeButton'>
+            <Text style={styles.quizLikes}>
+            <Image source={liked ? require('@/assets/images/like-2.png') : require('@/assets/images/like-1.png')}style={styles.icon} /> {likes}
+            </Text>
+          </TouchableOpacity>
 
-        {/* Touchable Bookmark Icon at the bottom right */}
-        <TouchableOpacity style={styles.bookmarkButton} onPress={() => handleBookmarkPress(props.id)} testID='bookmarkButton'>
-          <Image source={require('@/assets/images/bookmark-icon.png')} style={styles.icon} />
-        </TouchableOpacity>
-      </View>
-    </TouchableOpacity>
+          {/* Touchable Bookmark Icon at the bottom right */}
+          <TouchableOpacity style={styles.bookmarkButton} onPress={() => handleBookmarkPress(props.id)} testID='bookmarkButton'>
+            <Image source={require('@/assets/images/bookmark-icon.png')} style={styles.icon} />
+          </TouchableOpacity>
+        </View>
+      </TouchableOpacity>
+    </>
   );
 }
 

--- a/mobile/bulingo/app/components/quizCard.tsx
+++ b/mobile/bulingo/app/components/quizCard.tsx
@@ -92,7 +92,8 @@ export default function QuizCard(props: QuizCardProps){
           />
         </TouchableOpacity>
       </View>
-    </TouchableOpacity>
+      </TouchableOpacity>
+    </>
   );
 }
 


### PR DESCRIPTION
Fixes #848.

This PR implements the functionality needed for guests in the Notifications, Profile and Search tabs. The main changes are the following:

* A new guest modal has been created that prompts the user to either login or register. This component is reused in many pages. Whenever a guest tries to do something that they can't, they are shown this modal.
* The guests can't access the Profile tab.
* The guests can't access the Notifications tab.
* The guests can't press the like / bookmark button in the QuizCard.
* The guests can't press the like / bookmark button in the PostCard.
* The guests can't press the follow / unfollow buttons or the user card itself.
* The guests can't press the like / bookmark buttons in the CommentCard.
* Search is now usable by guests.