### PR TITLE
Show Profile Pictures in the Search Page (Mobile)

### DIFF
--- a/mobile/bulingo/app/(tabs)/search.tsx
+++ b/mobile/bulingo/app/(tabs)/search.tsx
@@ -80,6 +80,7 @@ export default function Tab() {
               ...item.data,
               buttonText: item.data.isFollowing ? "Unfollow" : "Follow",
               buttonStyleNo: item.data.username == username ? 3 : (item.data.isFollowing ? 1 : 2),
+              profilePictureUri: "http://64.226.76.231:8000" + item.data.profile_picture,
             }
           }));
           console.log(transformed_data)

--- a/mobile/bulingo/app/(tabs)/search.tsx
+++ b/mobile/bulingo/app/(tabs)/search.tsx
@@ -80,7 +80,7 @@ export default function Tab() {
               ...item.data,
               buttonText: item.data.isFollowing ? "Unfollow" : "Follow",
               buttonStyleNo: item.data.username == username ? 3 : (item.data.isFollowing ? 1 : 2),
-              profilePictureUri: "http://64.226.76.231:8000" + item.data.profile_picture,
+              profilePictureUri: item.data.profile_picture ? "http://64.226.76.231:8000" + item.data.profile_picture : "",
             }
           }));
           console.log(transformed_data)


### PR DESCRIPTION
Fixes #867.
This PR addresses the known bug where the UserCard component would not display the profile picture of a user when viewed in the search page. It is a really simple PR, you can test it by searching for the user 'ygz' in the search page.