### PR TITLE
feat(mobile): connect quiz bookmark feature to the backend on quiz pages

### DIFF
--- a/mobile/bulingo/app/(tabs)/quizzes/index.tsx
+++ b/mobile/bulingo/app/(tabs)/quizzes/index.tsx
@@ -127,7 +127,6 @@ const QuizFeed = () => {
 
 
   const handleBookmarkPress = async (quizId: number) => {
-    console.log('bookmarking quiz', quizId);
     const updatedQuizzes = await Promise.all(
       quizzes.map(async (quiz: any) => {
         if (quiz.id === quizId) {

--- a/mobile/bulingo/app/(tabs)/quizzes/index.tsx
+++ b/mobile/bulingo/app/(tabs)/quizzes/index.tsx
@@ -50,6 +50,7 @@ const QuizFeed = () => {
           level: quiz.level,
           likes: quiz.like_count,
           liked: quiz.is_liked,
+          bookmarked: quiz.is_bookmarked,
         }));
   
         setQuizzes((prevQuizzes: any) => (reset ? formattedResults : [...prevQuizzes, ...formattedResults]));
@@ -124,11 +125,52 @@ const QuizFeed = () => {
     setQuizzes(updatedQuizzes);
   };
 
+
+  const handleBookmarkPress = async (quizId: number) => {
+    console.log('bookmarking quiz', quizId);
+    const updatedQuizzes = await Promise.all(
+      quizzes.map(async (quiz: any) => {
+        if (quiz.id === quizId) {
+          let data = '';
+          try {
+            const response = await TokenManager.authenticatedFetch(`/quiz/bookmark/`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                quiz_id: quizId,
+              }),
+            });
+            
+            data = await response.json();
+            console.log(data);
+            let bookmarked = quiz.bookmarked;
+            if (response.ok) {
+              bookmarked = !quiz.bookmarked; // Toggle bookmark status
+            }
+            return { ...quiz, bookmarked };
+          } catch (error: any) {
+            setError(
+              'Failed to bookmark the quiz. Please try again. Error: ' +
+                JSON.stringify(data)
+            );
+          }
+        }
+        return quiz;
+      })
+    );
+    setQuizzes(updatedQuizzes);
+  };
+  
+  
+
   const renderQuizItem = ({ item }: { item: any }) => (
     <QuizCard
       {...item}
       onQuizPress={() => handleQuizPress(item.id)}
       onLikePress={() => handleLikePress(item.id)}
+      onBookmarkPress={() => {handleBookmarkPress(item.id)}}
     />
   );
 

--- a/mobile/bulingo/app/(tabs)/quizzes/quizDetails.tsx
+++ b/mobile/bulingo/app/(tabs)/quizzes/quizDetails.tsx
@@ -136,10 +136,6 @@ const QuizDetails = () => {
           Level: {quizDetails.level || 'N/A'}
         </Text>
 
-        {/* Bookmark button in the bottom right corner */}
-        <TouchableOpacity style={styles.bookmarkButton}>
-          <Image source={require('@/assets/images/bookmark-icon.png')} style={styles.bookmarkIcon} />
-        </TouchableOpacity>
       </View>
 
       <View style={styles.buttonContainer}>
@@ -248,16 +244,6 @@ const getStyles = (colorScheme: any) => {
       alignItems: 'center',
       color: '#ffffff',
       fontWeight: 'bold',
-    },
-    bookmarkButton: {
-      position: 'absolute',
-      bottom: 10,
-      right: 10,
-    },
-    bookmarkIcon: {
-      width: 24,
-      height: 24,
-      tintColor: isDark ? 'white' : 'black',
     },
   });
 };

--- a/mobile/bulingo/app/components/quizCard.tsx
+++ b/mobile/bulingo/app/components/quizCard.tsx
@@ -133,20 +133,23 @@ const getStyles = (colorScheme: any) => {
       position: 'absolute',
       bottom: 0,
       right: 10,
-      height: 50,
-      padding: 4,
+      height: 35,
     },
     quizLikes: {
       fontSize: 16,
       color: isDark ? '#fff' : '#000',
     },
     likeButton: {
-      flex: 2,
+      height: 35,
+      width: 35,
+      bottom: -5,
     },
     bookmarkButton: {
-      flex: 1,
+      height: 25,
+      width: 25,
       justifyContent: 'flex-end',
       alignItems: 'flex-end',
+      bottom: -15,
     },
     icon: {
       width: 30,

--- a/mobile/bulingo/app/components/quizCard.tsx
+++ b/mobile/bulingo/app/components/quizCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { TouchableOpacity, Image, Text, View, StyleSheet, useColorScheme } from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
 
 type QuizCardProps = {
   title: string,
@@ -9,6 +10,7 @@ type QuizCardProps = {
   description: string,
   liked: boolean,
   likes: number,
+  bookmarked: boolean,
   onQuizPress?: (id: number) => void;
   onLikePress?: (id: number) => void;
   onBookmarkPress?: (id: number) => void;  
@@ -66,7 +68,11 @@ export default function QuizCard(props: QuizCardProps){
 
         {/* Touchable Bookmark Icon at the bottom right */}
         <TouchableOpacity style={styles.bookmarkButton} onPress={() => handleBookmarkPress(props.id)} testID='bookmarkButton'>
-          <Image source={require('@/assets/images/bookmark-icon.png')} style={styles.icon} />
+          <FontAwesome 
+            name={props.bookmarked ? 'bookmark' : 'bookmark-o'} 
+            size={20}
+            color="black" 
+          />
         </TouchableOpacity>
       </View>
     </TouchableOpacity>


### PR DESCRIPTION
Fixes #859.

- Connected quiz bookmark on quiz feed to the backend.
- Connected quiz bookmark on quiz result to the backend.
- Quiz bookmark is removed from quiz details page. 
- The integrations are tested on an emulated android device.