### PR TITLE
Mobile Notifications & Admin Pages

### DIFF
--- a/mobile/bulingo/app/(tabs)/index.tsx
+++ b/mobile/bulingo/app/(tabs)/index.tsx
@@ -99,11 +99,11 @@ export default function Home() {
         />
       </View>
       <View style={styles.messageContainer}>
-        <PressableText style={styles.bigText} text="Welcome!"/>
-        <PressableText 
-          style={username? styles.username : styles.text}
-          text={username ? username :"You are not logged in. Register or Log In to access all features."}
-        />
+        <Text style={styles.bigText}>Welcome!</Text>
+        <Text 
+          style={username? styles.username : styles.text}>
+          {username ? username :"You are not logged in. Register or Log In to access all features."}
+        </Text>
       </View>
       {username ?
         <View style={styles.buttonsContainer}>

--- a/mobile/bulingo/app/(tabs)/notifications.tsx
+++ b/mobile/bulingo/app/(tabs)/notifications.tsx
@@ -126,6 +126,12 @@ const NotificationItem = ( {activity} : any ) => {
       else if(activity.verb == 'commented'){
         return "commented under your"
       }
+      else if(activity.verb == 'updated'){
+        return "updated your"
+      }
+      else if(activity.verb == "banned"){
+        return "was banned!"
+      }
       else {
         return "UNH: " + activity.verb
       }
@@ -155,6 +161,17 @@ const NotificationItem = ( {activity} : any ) => {
       else if(activity.verb == 'commented'){
         return "Post"
       }
+      else if(activity.verb == "updated"){
+        if(activity.object_type == "Quiz"){
+          return "Quiz";
+        } 
+        else if(activity.object_type == "Post") {
+          return "Post"
+        }
+        else {
+          return "UNH2 " + activity.object_type
+        }
+      }
       else if(activity.verb == 'deleted'){
         if(activity.object_type == "Quiz"){
           return `Quiz (${activity.object_name})`;
@@ -168,6 +185,9 @@ const NotificationItem = ( {activity} : any ) => {
         else {
           return "UNH2 " + activity.object_type
         }
+      }
+      else if(activity.verb == "banned"){
+        return "";
       }
       else {
         return "UNH: " + activity.verb

--- a/mobile/bulingo/app/(tabs)/notifications.tsx
+++ b/mobile/bulingo/app/(tabs)/notifications.tsx
@@ -48,40 +48,159 @@ const dbg_notifications = [
   }
 ];
 
+type Activity = {
+  actor: string,
+  affected_username: string,
+  object_id: number,
+  object_name: string,
+  object_type: string,
+  timestamp: string,
+  verb: string,
+};
+
 const NotificationItem = ( {activity} : any ) => {
-  const ActivityToComponent = (activity: any) => {
+  const ActivityToComponent = (activity: Activity) => {
     const username = TokenManager.getUsername();
-    const handlePress = (user: any) => {
-      if (user == username){
-        router.navigate("/(tabs)/profile")
-      } else {
-        router.navigate('/(tabs)/profile')
+
+    const handlePress = () => {
+      if(activity.verb == "deleted"){
+        return
+      }
+      else if(getLast() == "Quiz"){
+        goToQuiz();
+      }
+      else if(getLast() == "Post"){
+        goToPost();
+      }
+      else if(getLast() == "Comment"){
+        goToComment();
+      }
+      else {
+        console.error("Unhandled getLast: ", getLast());
+      }
+    };
+
+    const goToProfile = (_username: string) => {
+      router.navigate("/(tabs)/profile")
+      if(username != _username){
         setTimeout(() => {
-          router.push(`/(tabs)/profile/users/${user}`);
+          router.push(`/(tabs)/profile/users/${_username}`);
         }, 0);
       }
-      console.log("text Pressed");
-    };
+    }
+
+    const goToQuiz = () => {
+      router.push({
+        pathname: '/(tabs)/quizzes/quizDetails',
+        params: { id: activity.object_id },
+      });
+    }
+
+    const goToPost = () => {
+      router.push({pathname: '/(tabs)/forums/forumPostPage', params: {"id": activity.object_id }});
+    }
+
+    const goToComment = () => {
+      console.log("Comment pressed")
+    }
+
+    const getMiddle = () => {
+      if(activity.verb == 'solved'){
+        return 'solved your'
+      } 
+      else if(activity.verb == "followed") {
+        return "followed"
+      }
+      else if(activity.verb == 'unfollowed'){
+        return 'unfollowed'
+      }
+      else if(activity.verb == "deleted"){
+        return "deleted your"
+      }
+      else if(activity.verb == "liked"){
+        return "liked your"
+      }
+      else if(activity.verb == "created"){
+        return "created a"
+      }
+      else if(activity.verb == 'commented'){
+        return "commented under your"
+      }
+      else {
+        return "UNH: " + activity.verb
+      }
+    }
+
+    const getLast = () => {
+      if(activity.verb == 'solved'){
+        return 'Quiz'
+      } 
+      else if(activity.verb == "followed" || activity.verb == 'unfollowed') {
+        return activity.actor == username ? activity.actor : "You"
+      }
+      else if(activity.verb == "liked" || activity.verb == "created"){
+        if(activity.object_type == "Quiz"){
+          return "Quiz";
+        } 
+        else if(activity.object_type == "Post") {
+          return "Post"
+        }
+        else if (activity.object_type == "Comment"){
+          return "Comment"
+        } 
+        else {
+          return "UNH2 " + activity.object_type
+        }
+      }
+      else if(activity.verb == 'commented'){
+        return "Post"
+      }
+      else if(activity.verb == 'deleted'){
+        if(activity.object_type == "Quiz"){
+          return `Quiz (${activity.object_name})`;
+        } 
+        else if(activity.object_type == "Post") {
+          return `Post (${activity.object_name})`
+        }
+        else if (activity.object_type == "Comment"){
+          return `Comment (${activity.object_name})`
+        } 
+        else {
+          return "UNH2 " + activity.object_type
+        }
+      }
+      else {
+        return "UNH: " + activity.verb
+      }
+    }
+
     return (
       <Text style={styles.notificationText}>
-        <Text style={styles.clickableText} onPress={() => handlePress(activity.actor)}>
+        <Text style={styles.clickableText} onPress={() => goToProfile(activity.actor)}>
           {activity.actor==username ? "You" : activity.actor}
-        </Text>{' '}
-        {activity.verb}{' '}
-        <Text style={styles.clickableText} onPress={() => handlePress(activity.affected_username)}>
-          {activity.affected_username==username ? "You" : activity.affected_username}
-        </Text>{' '}
+        </Text>
+        {' '}
+        {getMiddle()}
+        {' '}
+        <Text style={activity.verb == "deleted" ? null : styles.clickableText} onPress={() => handlePress()}>
+          {getLast()}
+        </Text>
+        {' '}
         {timeDifferenceToString(activity.timestamp)}
       </Text>
     );
   }
 
+  const act: Activity = activity;
+  console.log(act);
   return (
     <View style={styles.notificationContainer}>
       <View style={styles.profileInfoTopPictureContainer}>
         <Image source={require("@/assets/images/profile-icon.png")} style={styles.profileInfoTopPicture}/>
       </View>
-      {ActivityToComponent(activity)}
+      <View style={styles.textWrapper}>
+        {ActivityToComponent(act)}
+      </View>
     </View>
   );
 }
@@ -151,6 +270,10 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.2,
     shadowRadius: 4,
   },
+  textWrapper: {
+    flexWrap: 'wrap',
+    alignItems: 'center',
+  },
   profileInfoTopPictureContainer: {
     marginRight: 12,
   },
@@ -160,7 +283,7 @@ const styles = StyleSheet.create({
     borderRadius: 20,
   },
   notificationText: {
-    fontSize: 16,
+    fontSize: 14,
     color: 'black',
   },
   title: {
@@ -174,7 +297,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   clickableText: {
-    fontSize: 16,
+    fontSize: 14,
     color: '#1a73e8', // Blue for clickable text
   },
 });

--- a/mobile/bulingo/app/(tabs)/profile/userCard.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/userCard.tsx
@@ -70,6 +70,34 @@ const UserCard = (props: UserCardProps) => {
       console.log("Wrong 'buttonStyleNo' prop passed to UserCard component!")
       break;
   }
+
+  const handleAdminBanUser = async() => {
+    const url = 'admin-ban/';
+    const params = {
+      'username': props.username,
+    }
+    console.log("in handleAdminBanUser")
+    console.log(url)
+    console.log(params)
+    try{
+      const response = await TokenManager.authenticatedFetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(params),
+      })
+
+      if (response.ok){
+        console.log("User banned successful")
+      } else {
+        console.log(response.status)
+      };
+      setIsAdminOptionsVisible(false);
+    } catch(error) {
+      console.error(error)
+    }
+  }
   
 
   return (
@@ -78,7 +106,7 @@ const UserCard = (props: UserCardProps) => {
         <AdminOptions onClose={()=>setIsAdminOptionsVisible(false)} options={[
           {
             text: "Ban User", 
-            onPress: ()=>{console.log("Ban User Pressed") /* Placeholder until endpoint is ready */ }
+            onPress: handleAdminBanUser
           }, 
         ]}
         />

--- a/mobile/bulingo/app/(tabs)/profile/userCard.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/userCard.tsx
@@ -76,9 +76,6 @@ const UserCard = (props: UserCardProps) => {
     const params = {
       'username': props.username,
     }
-    console.log("in handleAdminBanUser")
-    console.log(url)
-    console.log(params)
     try{
       const response = await TokenManager.authenticatedFetch(url, {
         method: 'POST',

--- a/mobile/bulingo/app/(tabs)/profile/userCard.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/userCard.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, {useState} from 'react';
 import { TouchableOpacity, View, Image, StyleSheet, Text } from 'react-native';
 import { RFPercentage } from 'react-native-responsive-fontsize';
 import { router } from 'expo-router';
 import TokenManager from '@/app/TokenManager';
+import AdminOptions from '@/app/components/adminOptions';
 
 type UserCardProps = {
   profilePictureUri: string,
@@ -16,6 +17,8 @@ type UserCardProps = {
 };
 
 const UserCard = (props: UserCardProps) => {
+  const [isAdminOptionsVisible, setIsAdminOptionsVisible] = useState(false);
+
   const handleButtonPress = async () => {
     const url = `profile/${props.buttonText.toLowerCase()}/`;
     const params = {
@@ -70,8 +73,23 @@ const UserCard = (props: UserCardProps) => {
   
 
   return (
-    <TouchableOpacity style={styles.followerContainer} onPress={handleCardPress} testID='card'>
-      <View style={styles.profilePictureContainer}>
+    <>
+      { isAdminOptionsVisible &&
+        <AdminOptions onClose={()=>setIsAdminOptionsVisible(false)} options={[
+          {
+            text: "Ban User", 
+            onPress: ()=>{console.log("Ban User Pressed") /* Placeholder until endpoint is ready */ }
+          }, 
+        ]}
+        />
+      }
+      <TouchableOpacity 
+        style={styles.followerContainer} 
+        onPress={handleCardPress} 
+        onLongPress={() => TokenManager.getIsAdmin() && setIsAdminOptionsVisible(true)}
+        testID='card'
+      >
+        <View style={styles.profilePictureContainer}>
         {props.profilePictureUri 
           ? (
             <Image 
@@ -104,6 +122,7 @@ const UserCard = (props: UserCardProps) => {
         }
       </View>
     </TouchableOpacity>
+    </>
   );
 };
 

--- a/mobile/bulingo/app/(tabs)/search.tsx
+++ b/mobile/bulingo/app/(tabs)/search.tsx
@@ -72,6 +72,7 @@ export default function Tab() {
               level: item.data.tags[0]
             }
           }));
+          console.log(transformed_data[0].data.tags)
         } else if (dataType == "user"){
           const username = TokenManager.getUsername();
           transformed_data = transformed_data.map((item:any) => ({
@@ -106,7 +107,6 @@ export default function Tab() {
             }
           }));
         }
-        console.log(transformed_data)
         setSearchResults(transformed_data);
       } else {
         console.error(response.status);

--- a/mobile/bulingo/app/TokenManager.ts
+++ b/mobile/bulingo/app/TokenManager.ts
@@ -9,7 +9,7 @@ class TokenManager {
 
   constructor() {
     this.username = null;
-    this.isAdmin = false
+    this.isAdmin = true;
   }
 
   async saveTokens(accessToken: string, refreshToken: string){

--- a/mobile/bulingo/app/TokenManager.ts
+++ b/mobile/bulingo/app/TokenManager.ts
@@ -5,9 +5,11 @@ const BASE_URL = "http://64.226.76.231:8000";
 
 class TokenManager {
   private username: string | null;
+  private isAdmin: boolean;
 
   constructor() {
     this.username = null;
+    this.isAdmin = false
   }
 
   async saveTokens(accessToken: string, refreshToken: string){
@@ -54,10 +56,17 @@ class TokenManager {
     this.username = username;
   }
 
+  setIsAdmin(isAdmin: boolean): void {
+    this.isAdmin = isAdmin;
+  }
+
   getUsername(): string|null {
     return this.username;
   }
 
+  getIsAdmin(): boolean {
+    return this.isAdmin;
+  }
   // Method to clear tokens
   async clearTokens() {
     await SecureStore.deleteItemAsync("accessToken");

--- a/mobile/bulingo/app/TokenManager.ts
+++ b/mobile/bulingo/app/TokenManager.ts
@@ -9,7 +9,7 @@ class TokenManager {
 
   constructor() {
     this.username = null;
-    this.isAdmin = true;
+    this.isAdmin = false;
   }
 
   async saveTokens(accessToken: string, refreshToken: string){

--- a/mobile/bulingo/app/components/adminOptions.tsx
+++ b/mobile/bulingo/app/components/adminOptions.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Text, View, StyleSheet, Modal, Pressable, TouchableOpacity, FlatList} from 'react-native';
+
+
+type AdminOptionsProps = {
+  options: Option[],
+  onClose: () => void,
+}
+
+type Option = {
+  text: string,
+  onPress: () => void,
+}
+
+export default function AdminOptions(props: AdminOptionsProps){
+  return (
+    <Modal
+      // animationType="slide"
+      transparent={true}
+      onRequestClose={props.onClose}
+    >
+      <Pressable style={styles.modalBackground} onPress={props.onClose}>
+        <Pressable style={styles.modalContent}>
+          <FlatList
+            data={props.options}
+            keyExtractor={(_, index)=>index.toString()}
+            renderItem={ ({item}) => {
+              return (
+                <View style={styles.optionContainer}>
+                  <TouchableOpacity onPress={item.onPress}>
+                    <Text style={styles.optionText}>{item.text}</Text>
+                  </TouchableOpacity>
+                </View>
+              );
+            }}
+            ListHeaderComponent={
+              <View style={styles.headerContainer}>
+                <Text style={styles.header}>Admin Options</Text>
+              </View>
+            }
+          />
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create(
+  {
+    modalBackground: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    },
+    modalContent: {
+      width: '80%',
+      maxHeight: '60%',
+      backgroundColor: 'white',
+      padding: 10,
+      borderRadius: 3,
+    },
+    headerContainer: {
+      borderBottomColor: 'black',
+      borderBottomWidth: 2,
+    },
+    header: {
+      fontSize: 26,
+      fontWeight: 'bold',
+    },
+    optionContainer: {
+      justifyContent: 'center',
+      padding: 10,
+      backgroundColor: 'white',
+      elevation: 2,
+    },
+    optionText: {
+      fontSize: 20,
+    },
+});

--- a/mobile/bulingo/app/components/commentcard.tsx
+++ b/mobile/bulingo/app/components/commentcard.tsx
@@ -3,6 +3,7 @@ import { View, Text, TouchableOpacity, StyleSheet, Image, Pressable } from 'reac
 import { FontAwesome } from '@expo/vector-icons';
 import TokenManager from '../TokenManager';
 import AdminOptions from './adminOptions';
+import { router } from 'expo-router';
 import PressableText from '../pressableText';
 
 interface CommentCardProps {
@@ -15,14 +16,44 @@ interface CommentCardProps {
   likes: number;
 }
 
+
+
 const CommentCard: React.FC<CommentCardProps> = ({ id, isBookmarked: initialBookmark, username, comment, onUpvote, liked, likes }) => {
     const [isBookmarked, setIsBookmarked] = useState(initialBookmark);
     const [isAdminOptionsVisible, setIsAdminOptionsVisible] = useState(false);
 
 
-  const toggleBookmark = () => {
-    setIsBookmarked(!isBookmarked);
-  };
+    const toggleBookmark = () => {
+        setIsBookmarked(!isBookmarked);
+    };
+
+    const handleAdminDeleteComment = async () => {
+        const url = 'post/comment/delete/';
+        const params = {
+          'comment_id': id,
+        }
+        console.log("in handleAdminDeleteComment")
+        console.log(url)
+        console.log(params)
+        try{
+          const response = await TokenManager.authenticatedFetch(url, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(params),
+          })
+    
+          if (response.ok){
+            console.log("Comment Deletion successful")
+          } else {
+            console.log(response.status)
+          };
+          router.replace('/?notification=Comment Deleted Successfully');
+        } catch(error) {
+          console.error(error)
+        }
+    }
 
     return (
         <>
@@ -30,7 +61,7 @@ const CommentCard: React.FC<CommentCardProps> = ({ id, isBookmarked: initialBook
             <AdminOptions onClose={()=>setIsAdminOptionsVisible(false)} options={[
             {
                 text: "Delete Comment",
-                onPress: ()=>{console.log("Delete Comment Pressed") /* Placeholder until endpoint is ready */ }
+                onPress: handleAdminDeleteComment
             },
             ]}
             />

--- a/mobile/bulingo/app/components/commentcard.tsx
+++ b/mobile/bulingo/app/components/commentcard.tsx
@@ -33,9 +33,6 @@ const CommentCard: React.FC<CommentCardProps> = ({ id, isBookmarked: initialBook
           'comment_id': id,
           'user': TokenManager.getUsername(),
         }
-        console.log("in handleAdminDeleteComment")
-        console.log(url)
-        console.log(params)
         try{
           const response = await TokenManager.authenticatedFetch(url, {
             method: 'DELETE',

--- a/mobile/bulingo/app/components/commentcard.tsx
+++ b/mobile/bulingo/app/components/commentcard.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Image, Pressable } from 'react-native';
 import { FontAwesome } from '@expo/vector-icons';
+import TokenManager from '../TokenManager';
+import AdminOptions from './adminOptions';
 import PressableText from '../pressableText';
 
 interface CommentCardProps {
@@ -14,25 +16,39 @@ interface CommentCardProps {
 }
 
 const CommentCard: React.FC<CommentCardProps> = ({ id, isBookmarked: initialBookmark, username, comment, onUpvote, liked, likes }) => {
-  const [isBookmarked, setIsBookmarked] = useState(initialBookmark);
+    const [isBookmarked, setIsBookmarked] = useState(initialBookmark);
+    const [isAdminOptionsVisible, setIsAdminOptionsVisible] = useState(false);
+
 
   const toggleBookmark = () => {
     setIsBookmarked(!isBookmarked);
   };
 
-  return (
-    <>
-      <View style={styles.cardContainer}>
-        <View style={styles.profileSection}>
-          <View style={styles.profileIcon}>
-            <FontAwesome name="user" size={24} color="#333" />
-          </View>
-          <Text style={styles.userName}>{username}</Text>
-        </View>
-
-        <View style={styles.commentSection}>
-          <PressableText style={styles.commentText} text={comment} />
-        </View>
+    return (
+        <>
+        { isAdminOptionsVisible &&
+            <AdminOptions onClose={()=>setIsAdminOptionsVisible(false)} options={[
+            {
+                text: "Delete Comment",
+                onPress: ()=>{console.log("Delete Comment Pressed") /* Placeholder until endpoint is ready */ }
+            },
+            ]}
+            />
+        }
+        <Pressable 
+            style={styles.cardContainer}
+            onLongPress={() => TokenManager.getIsAdmin() && setIsAdminOptionsVisible(true)}
+        >  
+            <View style={styles.profileSection}>
+                <View style={styles.profileIcon}>
+                    <FontAwesome name="user" size={24} color="#333" />
+                </View>
+                <Text style={styles.userName}>{username}</Text>
+            </View>
+            
+            <View style={styles.commentSection}>
+              <PressableText style={styles.commentText} text={comment} />
+            </View>
 
         <View style={styles.actionsContainer}>
           <TouchableOpacity style={styles.likeButton} onPress={() => onUpvote(id)} testID='likeButton'>
@@ -42,13 +58,17 @@ const CommentCard: React.FC<CommentCardProps> = ({ id, isBookmarked: initialBook
             </Text>
           </TouchableOpacity>
 
-          <TouchableOpacity onPress={toggleBookmark} style={styles.bookmarkButton}>
-            <FontAwesome name={isBookmarked ? 'bookmark' : 'bookmark-o'} size={20} color="black" />
-          </TouchableOpacity>
-        </View>
-      </View>
-    </>
-  );
+
+
+                {/* Bookmark Button */}
+                <TouchableOpacity onPress={toggleBookmark} style={styles.bookmarkButton}>
+                    <FontAwesome name={isBookmarked ? 'bookmark' : 'bookmark-o'} size={20} color="black" />
+                </TouchableOpacity>
+            </View>
+            
+        </Pressable>
+        </>
+    );
 };
 
 const styles = StyleSheet.create({

--- a/mobile/bulingo/app/components/commentcard.tsx
+++ b/mobile/bulingo/app/components/commentcard.tsx
@@ -31,13 +31,14 @@ const CommentCard: React.FC<CommentCardProps> = ({ id, isBookmarked: initialBook
         const url = 'post/comment/delete/';
         const params = {
           'comment_id': id,
+          'user': TokenManager.getUsername(),
         }
         console.log("in handleAdminDeleteComment")
         console.log(url)
         console.log(params)
         try{
           const response = await TokenManager.authenticatedFetch(url, {
-            method: 'POST',
+            method: 'DELETE',
             headers: {
               'Content-Type': 'application/json',
             },

--- a/mobile/bulingo/app/components/postcard.tsx
+++ b/mobile/bulingo/app/components/postcard.tsx
@@ -43,9 +43,6 @@ const PostCard: React.FC<PostCardProps> = ({
     const params = {
       'post_id': id,
     }
-    console.log("in handleAdminDeletePost")
-    console.log(url)
-    console.log(params)
     try{
       const response = await TokenManager.authenticatedFetch(url, {
         method: 'POST',

--- a/mobile/bulingo/app/components/postcard.tsx
+++ b/mobile/bulingo/app/components/postcard.tsx
@@ -3,6 +3,7 @@ import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native';
 import { FontAwesome } from '@expo/vector-icons';
 import TokenManager from '../TokenManager';
 import AdminOptions from './adminOptions';
+import TagEdit from './tagEdit';
 import PressableText from '../pressableText';
 
 interface PostCardProps {
@@ -34,10 +35,14 @@ const PostCard: React.FC<PostCardProps> = ({
   onPress,
 }) => {
   const [isAdminOptionsVisible, setIsAdminOptionsVisible] = useState(false);
+  const [isTagEditVisible, setIsTagEditVisible] = useState(false);
 
 
   return (
     <>
+      { isTagEditVisible && 
+        <TagEdit type="Quiz" id='placeholder' onClose={() => setIsTagEditVisible(false)}/>
+      }
       { isAdminOptionsVisible &&
         <AdminOptions onClose={()=>setIsAdminOptionsVisible(false)} options={[
           {
@@ -46,7 +51,10 @@ const PostCard: React.FC<PostCardProps> = ({
           },
           {
             text: "Change Post Tags",
-            onPress: ()=>{console.log("Change Post Tags Pressed") /* Placeholder until endpoint is ready */ }
+            onPress: ()=>{
+              setIsTagEditVisible(true);
+              console.log("Change Post Tags Pressed") /* Placeholder until endpoint is ready */ 
+            }
           },
         ]}
         />

--- a/mobile/bulingo/app/components/postcard.tsx
+++ b/mobile/bulingo/app/components/postcard.tsx
@@ -4,6 +4,7 @@ import { FontAwesome } from '@expo/vector-icons';
 import TokenManager from '../TokenManager';
 import AdminOptions from './adminOptions';
 import TagEdit from './tagEdit';
+import { router } from 'expo-router';
 import PressableText from '../pressableText';
 
 interface PostCardProps {
@@ -37,6 +38,34 @@ const PostCard: React.FC<PostCardProps> = ({
   const [isAdminOptionsVisible, setIsAdminOptionsVisible] = useState(false);
   const [isTagEditVisible, setIsTagEditVisible] = useState(false);
 
+  const handleAdminDeletePost = async () => {
+    const url = 'post/delete/';
+    const params = {
+      'post_id': id,
+    }
+    console.log("in handleAdminDeletePost")
+    console.log(url)
+    console.log(params)
+    try{
+      const response = await TokenManager.authenticatedFetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(params),
+      })
+
+      if (response.ok){
+        console.log("Post Deletion successful")
+        router.replace('/?notification=Post Deleted Successfully');
+      } else {
+        console.log(response.status)
+      };
+    } catch(error) {
+      console.error(error)
+    }
+  }
+  
 
   return (
     <>
@@ -47,7 +76,7 @@ const PostCard: React.FC<PostCardProps> = ({
         <AdminOptions onClose={()=>setIsAdminOptionsVisible(false)} options={[
           {
             text: "Delete Post",
-            onPress: ()=>{console.log("Delete Post Pressed") /* Placeholder until endpoint is ready */ }
+            onPress: handleAdminDeletePost
           },
           {
             text: "Change Post Tags",

--- a/mobile/bulingo/app/components/postcard.tsx
+++ b/mobile/bulingo/app/components/postcard.tsx
@@ -67,7 +67,7 @@ const PostCard: React.FC<PostCardProps> = ({
   return (
     <>
       { isTagEditVisible && 
-        <TagEdit type="Quiz" id='placeholder' onClose={() => setIsTagEditVisible(false)}/>
+        <TagEdit type="Quiz" id={id} onClose={() => setIsTagEditVisible(false)} tags={tags}/>
       }
       { isAdminOptionsVisible &&
         <AdminOptions onClose={()=>setIsAdminOptionsVisible(false)} options={[

--- a/mobile/bulingo/app/components/postcard.tsx
+++ b/mobile/bulingo/app/components/postcard.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, {useState} from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native';
 import { FontAwesome } from '@expo/vector-icons';
+import TokenManager from '../TokenManager';
+import AdminOptions from './adminOptions';
 import PressableText from '../pressableText';
 
 interface PostCardProps {
@@ -31,49 +33,69 @@ const PostCard: React.FC<PostCardProps> = ({
   onBookmark,
   onPress,
 }) => {
+  const [isAdminOptionsVisible, setIsAdminOptionsVisible] = useState(false);
 
 
   return (
-    <TouchableOpacity onPress={onPress} testID='card'>
-      <View style={styles.cardContainer}>
-        <View style={styles.header}>
-          {/* <PressableText style={styles.title}</> */}
-        <PressableText style={styles.title} text={title}/>
-          {/* <Text style={styles.title}>{title}</Text> */}
-          <Text style={styles.author}>by {author}</Text>
-        </View>
-        <View style={styles.tagsContainer}>
-          {tags && tags.map((tag, index) => (
-            <View key={index} style={styles.levelBadge}>
-              <Text style={styles.levelText}>{tag}</Text>
-            </View>
-          ))}
-        </View>
-        <View style={styles.footer}>
-          <View style={styles.actionsContainer}>
-            {/* <TouchableOpacity onPress={onUpvote} style={styles.upvoteButton}>
-              <FontAwesome name="arrow-up" size={20} color="green" />
-              <Text style={styles.upvoteCount}>{likes}</Text>
-            </TouchableOpacity>
-             */}
-            <TouchableOpacity style={styles.likeButton} onPress={() => onUpvote(id)} testID={'likeButton'}>
-             <Text style={styles.quizLikes}>
-            <Image source={liked ? require('../../assets/images/like-2.png') : require('../../assets/images/like-1.png')}style={styles.icon} /> 
-            {likes}
-            </Text>
-            </TouchableOpacity>
+    <>
+      { isAdminOptionsVisible &&
+        <AdminOptions onClose={()=>setIsAdminOptionsVisible(false)} options={[
+          {
+            text: "Delete Post",
+            onPress: ()=>{console.log("Delete Post Pressed") /* Placeholder until endpoint is ready */ }
+          },
+          {
+            text: "Change Post Tags",
+            onPress: ()=>{console.log("Change Post Tags Pressed") /* Placeholder until endpoint is ready */ }
+          },
+        ]}
+        />
+      }
+      <TouchableOpacity 
+        onPress={onPress} 
+        onLongPress={() => TokenManager.getIsAdmin() && setIsAdminOptionsVisible(true)}
+        testID='card'
+      >
+        <View style={styles.cardContainer}>
+          <View style={styles.header}>
+            {/* <PressableText style={styles.title}</> */}
+          <PressableText style={styles.title} text={title}/>
+            {/* <Text style={styles.title}>{title}</Text> */}
+            <Text style={styles.author}>by {author}</Text>
+          </View>
+          <View style={styles.tagsContainer}>
+            {tags && tags.map((tag, index) => (
+              <View key={index} style={styles.levelBadge}>
+                <Text style={styles.levelText}>{tag}</Text>
+              </View>
+            ))}
+          </View>
+          <View style={styles.footer}>
+            <View style={styles.actionsContainer}>
+              {/* <TouchableOpacity onPress={onUpvote} style={styles.upvoteButton}>
+                <FontAwesome name="arrow-up" size={20} color="green" />
+                <Text style={styles.upvoteCount}>{likes}</Text>
+              </TouchableOpacity>
+                */}
+              <TouchableOpacity style={styles.likeButton} onPress={() => onUpvote(id)} testID={'likeButton'}>
+                <Text style={styles.quizLikes}>
+              <Image source={liked ? require('../../assets/images/like-2.png') : require('../../assets/images/like-1.png')}style={styles.icon} /> 
+              {likes}
+              </Text>
+              </TouchableOpacity>
 
-            <TouchableOpacity onPress={onBookmark} style={styles.bookmarkButton} testID={'bookmarkButton'}>
-              <FontAwesome 
-                name={isBookmarked ? 'bookmark' : 'bookmark-o'} 
-                size={20} 
-                color="black" 
-              />
-            </TouchableOpacity>
+              <TouchableOpacity onPress={onBookmark} style={styles.bookmarkButton} testID={'bookmarkButton'}>
+                <FontAwesome 
+                  name={isBookmarked ? 'bookmark' : 'bookmark-o'} 
+                  size={20} 
+                  color="black" 
+                />
+              </TouchableOpacity>
+            </View>
           </View>
         </View>
-      </View>
-    </TouchableOpacity>
+      </TouchableOpacity>
+    </>
   );
 };
 

--- a/mobile/bulingo/app/components/quizCard.tsx
+++ b/mobile/bulingo/app/components/quizCard.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { TouchableOpacity, Image, Text, View, StyleSheet, useColorScheme } from 'react-native';
+import AdminOptions from './adminOptions';
+import TokenManager from '../TokenManager';
 import { FontAwesome } from '@expo/vector-icons';
 import PressableText from '../pressableText';
 
@@ -21,6 +23,7 @@ type QuizCardProps = {
 export default function QuizCard(props: QuizCardProps){
   const [likes, setLikes] = useState(props.likes);
   const [liked, setLiked] = useState(props.liked);
+  const [isAdminOptionsVisible, setIsAdminOptionsVisible] = useState(false);
 
   const colorScheme = useColorScheme();
   const styles = getStyles(colorScheme);
@@ -47,28 +50,42 @@ export default function QuizCard(props: QuizCardProps){
   };
 
   return (
-    <TouchableOpacity
-      style={[styles.quizItem, styles.elevation]}
-      onPress={() => handleQuizPress(props.id)}
-      testID='quiz'
-    >
-      <View style={styles.quizTop}>
-                <PressableText style={styles.quizTitle} text={props.title}/>
-                <PressableText style={styles.quizDescription} text={props.description}/>
-        
+    <>
+      { isAdminOptionsVisible &&
+        <AdminOptions onClose={()=>setIsAdminOptionsVisible(false)} options={[
+          {
+            text: "Delete Quiz", 
+            onPress: ()=>{console.log("Delete Quiz Pressed") /* Placeholder until endpoint is ready */ }
+          }, 
+          {
+            text: "Change Quiz Tags", 
+            onPress: ()=>{console.log("Change Quiz Tags Pressed") /* Placeholder until endpoint is ready */ }
+          }, 
+        ]}
+        />
+      }
+      <TouchableOpacity
+        style={[styles.quizItem, styles.elevation]}
+        onPress={() => handleQuizPress(props.id)}
+        onLongPress={() => TokenManager.getIsAdmin() && setIsAdminOptionsVisible(true)}
+        testID='quiz'
+      >
+        <View style={styles.quizTop}>
+          <PressableText style={styles.quizTitle} text={props.title}/>
+          <PressableText style={styles.quizDescription} text={props.description}/>
         {/* <Text style={styles.quizTitle}>{props.title}</Text>
         <Text style={styles.quizDescription}>{props.description}</Text> */}
-      </View>
-      <View style={styles.quizBottom}>
-        <View style={styles.quizBottomLeft}>
-          <Text style={styles.quizAuthor}>by {props.author}</Text>
-          <Text style={styles.quizLevel}>{props.level}</Text>
         </View>
-        <TouchableOpacity style={styles.likeButton} onPress={() => handleLikePress(props.id)} testID='likeButton'>
-          <Text style={styles.quizLikes}>
-          <Image source={liked ? require('@/assets/images/like-2.png') : require('@/assets/images/like-1.png')}style={styles.icon} /> {likes}
-          </Text>
-        </TouchableOpacity>
+        <View style={styles.quizBottom}>
+          <View style={styles.quizBottomLeft}>
+            <Text style={styles.quizAuthor}>by {props.author}</Text>
+            <Text style={styles.quizLevel}>{props.level}</Text>
+          </View>
+          <TouchableOpacity style={styles.likeButton} onPress={() => handleLikePress(props.id)} testID='likeButton'>
+            <Text style={styles.quizLikes}>
+            <Image source={liked ? require('@/assets/images/like-2.png') : require('@/assets/images/like-1.png')}style={styles.icon} /> {likes}
+            </Text>
+          </TouchableOpacity>
 
         {/* Touchable Bookmark Icon at the bottom right */}
         <TouchableOpacity style={styles.bookmarkButton} onPress={() => handleBookmarkPress(props.id)} testID='bookmarkButton'>

--- a/mobile/bulingo/app/components/quizCard.tsx
+++ b/mobile/bulingo/app/components/quizCard.tsx
@@ -80,7 +80,7 @@ export default function QuizCard(props: QuizCardProps){
   return (
     <>
       { isTagEditVisible && 
-        <TagEdit type="Quiz" id='placeholder' onClose={() => setIsTagEditVisible(false)}/>
+        <TagEdit type="Quiz" id='placeholder' onClose={() => setIsTagEditVisible(false)} tags={[props.level]}/>
       }
       { isAdminOptionsVisible &&
         <AdminOptions onClose={()=>setIsAdminOptionsVisible(false)} options={[
@@ -131,6 +131,7 @@ export default function QuizCard(props: QuizCardProps){
         </TouchableOpacity>
       </View>
     </TouchableOpacity>
+  </>
   );
 }
 

--- a/mobile/bulingo/app/components/quizCard.tsx
+++ b/mobile/bulingo/app/components/quizCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { TouchableOpacity, Image, Text, View, StyleSheet, useColorScheme } from 'react-native';
 import AdminOptions from './adminOptions';
+import TagEdit from './tagEdit';
 import TokenManager from '../TokenManager';
 import { FontAwesome } from '@expo/vector-icons';
 import PressableText from '../pressableText';
@@ -24,6 +25,7 @@ export default function QuizCard(props: QuizCardProps){
   const [likes, setLikes] = useState(props.likes);
   const [liked, setLiked] = useState(props.liked);
   const [isAdminOptionsVisible, setIsAdminOptionsVisible] = useState(false);
+  const [isTagEditVisible, setIsTagEditVisible] = useState(false);
 
   const colorScheme = useColorScheme();
   const styles = getStyles(colorScheme);
@@ -51,6 +53,9 @@ export default function QuizCard(props: QuizCardProps){
 
   return (
     <>
+      { isTagEditVisible && 
+        <TagEdit type="Quiz" id='placeholder' onClose={() => setIsTagEditVisible(false)}/>
+      }
       { isAdminOptionsVisible &&
         <AdminOptions onClose={()=>setIsAdminOptionsVisible(false)} options={[
           {
@@ -59,7 +64,10 @@ export default function QuizCard(props: QuizCardProps){
           }, 
           {
             text: "Change Quiz Tags", 
-            onPress: ()=>{console.log("Change Quiz Tags Pressed") /* Placeholder until endpoint is ready */ }
+            onPress: ()=>{
+              setIsTagEditVisible(true);
+              console.log("Change Quiz Tags Pressed"); /* Placeholder until endpoint is ready */ 
+            }
           }, 
         ]}
         />

--- a/mobile/bulingo/app/components/quizCard.tsx
+++ b/mobile/bulingo/app/components/quizCard.tsx
@@ -3,6 +3,7 @@ import { TouchableOpacity, Image, Text, View, StyleSheet, useColorScheme } from 
 import AdminOptions from './adminOptions';
 import TagEdit from './tagEdit';
 import TokenManager from '../TokenManager';
+import { router } from 'expo-router';
 import { FontAwesome } from '@expo/vector-icons';
 import PressableText from '../pressableText';
 
@@ -51,6 +52,34 @@ export default function QuizCard(props: QuizCardProps){
     props.onBookmarkPress && props.onBookmarkPress(id);
   };
 
+  const handleAdminDeleteQuiz = async () => {
+    const url = 'quiz/delete/';
+    const params = {
+      'quiz_id': props.id,
+    }
+    console.log("in handleAdminDeleteQuiz")
+    console.log(url)
+    console.log(params)
+    try{
+      const response = await TokenManager.authenticatedFetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(params),
+      })
+
+      if (response.ok){
+        console.log("Quiz Deletion successful")
+      } else {
+        console.log(response.status)
+      };
+      router.replace('/?notification=Quiz Deleted Successfully');
+    } catch(error) {
+      console.error(error)
+    }
+  }
+
   return (
     <>
       { isTagEditVisible && 
@@ -60,7 +89,7 @@ export default function QuizCard(props: QuizCardProps){
         <AdminOptions onClose={()=>setIsAdminOptionsVisible(false)} options={[
           {
             text: "Delete Quiz", 
-            onPress: ()=>{console.log("Delete Quiz Pressed") /* Placeholder until endpoint is ready */ }
+            onPress: handleAdminDeleteQuiz
           }, 
           {
             text: "Change Quiz Tags", 

--- a/mobile/bulingo/app/components/quizCard.tsx
+++ b/mobile/bulingo/app/components/quizCard.tsx
@@ -57,9 +57,6 @@ export default function QuizCard(props: QuizCardProps){
     const params = {
       'quiz_id': props.id,
     }
-    console.log("in handleAdminDeleteQuiz")
-    console.log(url)
-    console.log(params)
     try{
       const response = await TokenManager.authenticatedFetch(url, {
         method: 'POST',

--- a/mobile/bulingo/app/components/quizCard.tsx
+++ b/mobile/bulingo/app/components/quizCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { TouchableOpacity, Image, Text, View, StyleSheet, useColorScheme } from 'react-native';
 import AdminOptions from './adminOptions';
 import TagEdit from './tagEdit';
@@ -27,6 +27,7 @@ export default function QuizCard(props: QuizCardProps){
   const [liked, setLiked] = useState(props.liked);
   const [isAdminOptionsVisible, setIsAdminOptionsVisible] = useState(false);
   const [isTagEditVisible, setIsTagEditVisible] = useState(false);
+  const [tags, setTags] = useState<string[]>([]);
 
   const colorScheme = useColorScheme();
   const styles = getStyles(colorScheme);
@@ -77,10 +78,35 @@ export default function QuizCard(props: QuizCardProps){
     }
   }
 
+  useEffect(() => {
+    fetchQuizTags();
+  },[])
+
+  const fetchQuizTags = async () => {
+    const url = `quiz/${props.id}/`;
+    try {
+      const response = await TokenManager.authenticatedFetch(url, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      if(response.ok){
+        const res = await response.json()
+        setTags(res.quiz.tags);
+        console.log(res);
+      } else{
+        console.warn(response.status)
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
   return (
     <>
       { isTagEditVisible && 
-        <TagEdit type="Quiz" id='placeholder' onClose={() => setIsTagEditVisible(false)} tags={[props.level]}/>
+        <TagEdit type="Quiz" id='placeholder' onClose={() => setIsTagEditVisible(false)} tags={tags}/>
       }
       { isAdminOptionsVisible &&
         <AdminOptions onClose={()=>setIsAdminOptionsVisible(false)} options={[
@@ -113,7 +139,7 @@ export default function QuizCard(props: QuizCardProps){
         <View style={styles.quizBottom}>
           <View style={styles.quizBottomLeft}>
             <Text style={styles.quizAuthor}>by {props.author}</Text>
-            <Text style={styles.quizLevel}>{props.level}</Text>
+            {props.level && <Text style={styles.quizLevel}>{props.level}</Text>}
           </View>
           <TouchableOpacity style={styles.likeButton} onPress={() => handleLikePress(props.id)} testID='likeButton'>
             <Text style={styles.quizLikes}>

--- a/mobile/bulingo/app/components/tagEdit.tsx
+++ b/mobile/bulingo/app/components/tagEdit.tsx
@@ -1,0 +1,298 @@
+import React, {useState, useEffect} from 'react';
+import { ActivityIndicator, View, StyleSheet, TouchableOpacity, Modal, Pressable, FlatList, Text, TextInput, Image } from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
+import TokenManager from '../TokenManager';
+
+type TagEditProps={
+  type: 'Post'|'Quiz';
+  id: string,  // The id of the post or quiz
+  onClose: ()=>void;
+}
+
+
+export default function TagEdit(props: TagEditProps){
+  const [tags, setTags] = useState<string[]>(['A1', 'tag1', 'tag2', 'tag3', 
+    'tag4', 'tag5', 'tag6', 'tag7', 'tag8', 'tag9', 'tag5', 'tag6', 'tag7', 'tag8', 'tag9']);
+  const [filteredTags, setFilteredTags] = useState<string[]>(tags);
+  const [searchQuery, setSearchQuery] = useState<string>("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [addTagModalVisible, setAddTagModalVisible] = useState(false);
+  const [addTagInput , setAddTagInput] = useState("");
+
+  useEffect(() => {
+    setFilteredTags(tags.filter((tag) => tag.toLowerCase().includes(searchQuery.toLowerCase())));
+  }, [tags, searchQuery]);
+
+
+  useEffect(() => {
+    const fetchTags = async () => { 
+      const username = TokenManager.getUsername()
+      if (username === null){
+        console.error("username is null")
+        return
+      }
+      const params = {
+        'user': username,
+       };
+
+      const url = 'fetch_tags/';  // Placeholder, change when endpoint is ready
+      try {
+        const response = await TokenManager.authenticatedFetch(url, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+        const res = await response.json();
+        if (response.ok){
+          setTags(res);
+        } else {
+          console.log(response.status)
+        };
+      } catch (error) {
+        console.error(error);
+      }
+      setIsLoading(false);
+    };
+    fetchTags();
+  }, []);
+
+  if (isLoading){
+    return (
+      <Modal transparent={true} onRequestClose={props.onClose}>
+        <ActivityIndicator size={20} color={'red'}/>
+      </Modal>
+    );
+  }
+
+  const removeTag = (tag:string) => {
+    return (async () => {
+      setTags(tags.filter((item) => item !== tag))
+
+      const username = TokenManager.getUsername()
+      if (username === null){
+        console.error("username is null")
+        return
+      }
+      const params = {
+        'user': username,
+       };
+
+      const url = 'delete_tags/';  // Placeholder, change when endpoint is ready
+      try {
+        const response = await TokenManager.authenticatedFetch(url, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+        const res = await response.json();
+        if (!response.ok){
+          console.log(response.status)
+        };
+      } catch (error) {
+        console.error(error);
+      }
+    });
+  }
+
+  const addTag = async () => {
+    if (!tags.includes(addTagInput)) {
+      tags.push(addTagInput);
+
+      const username = TokenManager.getUsername()
+      if (username === null){
+        console.error("username is null")
+        return
+      }
+      const params = {
+        'user': username,
+       };
+
+      const url = 'add_tags/';  // Placeholder, change when endpoint is ready
+      try {
+        const response = await TokenManager.authenticatedFetch(url, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+        const res = await response.json();
+        if (!response.ok){
+          console.log(response.status)
+        };
+      } catch (error) {
+        console.error(error);
+      }
+    }
+    setAddTagModalVisible(false);
+  }
+
+  return (
+    <Modal
+      // animationType="slide"
+      transparent={true}
+      onRequestClose={props.onClose}
+    >
+      { addTagModalVisible && 
+        <Modal
+          // animationType="slide"
+          transparent={true}
+          onRequestClose={() => setAddTagModalVisible(false)}
+        >
+          <Pressable style={styles.modalBackground} onPress={() => setAddTagModalVisible(false)}>
+            <View style={styles.modalContent}>
+              <View style={styles.headerContainer}>
+                <Text style={styles.header}>Add a Tag to {props.type} </Text>
+              </View>
+              <TextInput
+                style={styles.addTagInput}
+                placeholder="Enter the tag"
+                placeholderTextColor={'#666'}
+                onChangeText={(text) => setAddTagInput(text)}
+              />
+              <View style={styles.buttonContainer}>
+                <TouchableOpacity style={styles.addButtonRectangle} onPress={addTag}>
+                  <Text style={styles.buttonText}>Add Tag</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </Pressable>
+        </Modal>
+      }
+      <Pressable style={styles.modalBackground} onPress={props.onClose}>
+        <View style={styles.modalContent}>
+          <FlatList
+            data={filteredTags}
+            keyExtractor={(_, index)=>index.toString()}
+            renderItem={ ({item}) => {
+              return (
+                <Pressable style={styles.tagContainer}>
+                  <TouchableOpacity onPress={removeTag(item)}>
+                    <FontAwesome name="times" size={20} color='red' style={styles.xmark}/>
+                  </TouchableOpacity>
+                  <View style={styles.tagBox}>
+                    <Text style={styles.tagText}>{item}</Text>
+                  </View>
+                </Pressable>
+              );
+            }}
+            ListHeaderComponent={
+              <>
+                <View style={styles.headerContainer}>
+                  <Text style={styles.header}>Change {props.type} Tags</Text>
+                </View>
+                <View style={styles.searchContainer}>
+                  <TextInput
+                    style={styles.searchBar}
+                    placeholder="Search quiz tags"
+                    placeholderTextColor={'#555'}
+                    onChangeText={(text) => {setSearchQuery(text)}}
+                  />
+                  <TouchableOpacity style={styles.addButton} onPress={() => setAddTagModalVisible(true)}>
+                    <Image source={require('@/assets/images/add-icon.png')} style={styles.icon} />
+                  </TouchableOpacity>
+                </View>
+              </>
+            }
+          />
+        </View>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create(
+  {
+    modalBackground: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: "rgba(0, 0, 0, 0.5)",
+    },
+    modalContent: {
+      width: '80%',
+      maxHeight: '60%',
+      backgroundColor: 'white',
+      padding: 10,
+      borderRadius: 3,
+    },
+    headerContainer: {
+      borderBottomColor: 'black',
+      borderBottomWidth: 2,
+    },
+    header: {
+      fontSize: 26,
+      fontWeight: 'bold',
+    },
+    tagContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      padding: 5,
+      backgroundColor: 'white',
+    },
+    tagBox: {
+      borderWidth: 2,
+      borderRadius: 10,
+      paddingHorizontal: 6,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    tagText: {
+      fontSize: 16,
+    },
+    xmark: {
+      marginTop: 4,
+      margin: 3,
+    },
+    searchContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 16,
+      padding: 8,
+      borderRadius: 8,
+      backgroundColor: 'white',
+    },
+    buttonContainer: {
+      alignItems: 'center',
+    },
+    addButton: {
+      marginLeft: 10,
+    },
+    addButtonRectangle: {
+      margin: 10,
+      alignItems: 'center',
+      flex: 0,
+      paddingHorizontal: 10,
+      paddingVertical: 5,
+      borderRadius: 10,
+      elevation: 2,
+      backgroundColor: 'rgba(31, 23, 225, 0.8)',
+    },
+    buttonText: {
+      color: "white",
+      fontSize: 18,
+      fontWeight: 'bold',
+    },
+    icon: {
+      width: 30,
+      height: 30,
+      tintColor: 'black',
+    },
+    searchBar: {
+      flex: 1,
+      padding: 10,
+      backgroundColor: '#e8e8e8',
+      borderRadius: 8,
+      color: 'black',
+    },
+    addTagInput: {
+      marginTop: 15,
+      margin: 10,
+      flex: 0,
+      padding: 10,
+      backgroundColor: '#e8e8e8',
+      borderRadius: 8,
+      color: 'black',
+    },
+});

--- a/mobile/bulingo/app/components/tagEdit.tsx
+++ b/mobile/bulingo/app/components/tagEdit.tsx
@@ -6,64 +6,21 @@ import TokenManager from '../TokenManager';
 type TagEditProps={
   type: 'Post'|'Quiz';
   id: string,  // The id of the post or quiz
+  tags: string[],
   onClose: ()=>void;
 }
 
 
 export default function TagEdit(props: TagEditProps){
-  const [tags, setTags] = useState<string[]>(['A1', 'tag1', 'tag2', 'tag3', 
-    'tag4', 'tag5', 'tag6', 'tag7', 'tag8', 'tag9', 'tag5', 'tag6', 'tag7', 'tag8', 'tag9']);
+  const [tags, setTags] = useState<string[]>(props.tags);
   const [filteredTags, setFilteredTags] = useState<string[]>(tags);
   const [searchQuery, setSearchQuery] = useState<string>("");
-  const [isLoading, setIsLoading] = useState(true);
   const [addTagModalVisible, setAddTagModalVisible] = useState(false);
   const [addTagInput , setAddTagInput] = useState("");
 
   useEffect(() => {
     setFilteredTags(tags.filter((tag) => tag.toLowerCase().includes(searchQuery.toLowerCase())));
   }, [tags, searchQuery]);
-
-
-  useEffect(() => {
-    const fetchTags = async () => { 
-      const username = TokenManager.getUsername()
-      if (username === null){
-        console.error("username is null")
-        return
-      }
-      const params = {
-        'user': username,
-       };
-
-      const url = 'fetch_tags/';  // Placeholder, change when endpoint is ready
-      try {
-        const response = await TokenManager.authenticatedFetch(url, {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        });
-        const res = await response.json();
-        if (response.ok){
-          setTags(res);
-        } else {
-          console.log(response.status)
-        };
-      } catch (error) {
-        console.error(error);
-      }
-      setIsLoading(false);
-    };
-    fetchTags();
-  }, []);
-
-  if (isLoading){
-    return (
-      <Modal transparent={true} onRequestClose={props.onClose}>
-        <ActivityIndicator size={20} color={'red'}/>
-      </Modal>
-    );
-  }
 
   const removeTag = (tag:string) => {
     return (async () => {
@@ -74,22 +31,33 @@ export default function TagEdit(props: TagEditProps){
         console.error("username is null")
         return
       }
-      const params = {
-        'user': username,
+      const params = props.type == 'Post' ? {
+        tags: tags.filter((item) => item !== tag),
+       } : {
+        quiz: {
+          tags: tags.filter((item) => item !== tag),
+        }
        };
 
-      const url = 'delete_tags/';  // Placeholder, change when endpoint is ready
+      const url = props.type == 'Post' ? `post/update/${props.id}/` : "quiz/update/";
+      console.log(url);
+      console.log(params);
+
       try {
         const response = await TokenManager.authenticatedFetch(url, {
-          method: 'GET',
+          method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
+          body: JSON.stringify(params),
         });
-        const res = await response.json();
-        if (!response.ok){
-          console.log(response.status)
-        };
+
+        if (response.ok){
+          const res = await response.json();
+          console.log(res);
+        } else {
+          console.log("removeTag failed: ", response.status)
+        }
       } catch (error) {
         console.error(error);
       }
@@ -105,22 +73,33 @@ export default function TagEdit(props: TagEditProps){
         console.error("username is null")
         return
       }
-      const params = {
-        'user': username,
+      const params = props.type == 'Post' ? {
+        'tags': [...tags, addTagInput],
+       } : {
+        quiz: {
+          tags: [...tags, addTagInput],
+        }
        };
 
-      const url = 'add_tags/';  // Placeholder, change when endpoint is ready
+      const url = props.type == 'Post' ? `post/update/${props.id}/` : "quiz/update/";      
+      console.log(url);
+      console.log(params);
+
       try {
         const response = await TokenManager.authenticatedFetch(url, {
-          method: 'GET',
+          method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
+          body: JSON.stringify(params),
         });
-        const res = await response.json();
-        if (!response.ok){
-          console.log(response.status)
-        };
+
+        if (response.ok){
+          const res = await response.json();
+          console.log(res);
+        } else {
+          console.log("addTag failed: ", response.status)
+        }
       } catch (error) {
         console.error(error);
       }

--- a/mobile/bulingo/app/components/tagEdit.tsx
+++ b/mobile/bulingo/app/components/tagEdit.tsx
@@ -98,7 +98,7 @@ export default function TagEdit(props: TagEditProps){
 
   const addTag = async () => {
     if (!tags.includes(addTagInput)) {
-      tags.push(addTagInput);
+      setTags([...tags, addTagInput])
 
       const username = TokenManager.getUsername()
       if (username === null){

--- a/mobile/bulingo/app/login.tsx
+++ b/mobile/bulingo/app/login.tsx
@@ -44,6 +44,28 @@ export default function Home() {
           TokenManager.saveTokens(access, refresh);
           TokenManager.setUsername(username);
           Alert.set("Login Successful");
+          try{
+            const isAdminUrl = 'admin-check/';
+            const responseIsAdmin = await TokenManager.authenticatedFetch(isAdminUrl, {
+              method: 'GET',
+              headers: {
+                "Content-Type": "application/json",
+              },
+            })
+
+            if (response.ok){
+              const result = await responseIsAdmin.json();
+              TokenManager.setIsAdmin(result.is_admin)
+            } else {
+              console.warn(response.status);
+            }
+          } catch (error) {
+            console.error(error);
+          }
+
+
+
+
           router.navigate('/');
         } else {
           console.warn(json);

--- a/mobile/bulingo/app/login.tsx
+++ b/mobile/bulingo/app/login.tsx
@@ -36,15 +36,20 @@ export default function Home() {
         },
         body: JSON.stringify(params),
       });
-      const json = await response.json();
-      if ("access" in json){
-        const { access, refresh } = json;
-        TokenManager.saveTokens(access, refresh);
-        TokenManager.setUsername(username);
-        Alert.set("Login Successful");
-        router.navigate('/');
+
+      if (response.ok){
+        const json = await response.json();
+        if ("access" in json){
+          const { access, refresh } = json;
+          TokenManager.saveTokens(access, refresh);
+          TokenManager.setUsername(username);
+          Alert.set("Login Successful");
+          router.navigate('/');
+        } else {
+          console.warn(json);
+        }
       } else {
-        setNotification("Incorrect Login information.")
+        setNotification("Incorrect Login information. You may be banned. ")
         setIsErrorVisible(true);
       };
     } catch (error) {


### PR DESCRIPTION
Fixes #853. Fixes #737.

This is a huge PR that includes a lot of really important changes. You can look at the individual commit messages for more information. To give you a general overview, the following are the main problems addressed in this PR:

* Add an admin modal component that shows up if an admin presses and holds some components
* Give the option to ban a user after pressing their user card
* Give the option to change the tags of a quiz after pressing the quiz card
* Give the option to delete a quiz after pressing the quiz card
* Give the options to delete/change tags of post after pressing the post card
* Give the option to delete a comment after pressing the comment card
* Correctly check if a user is an admin when they log in.
* Update notifications with new messages.
* Change the home page to not use PressableText