### PR TITLE
feat(mobile): enable image upload on quiz creation

### DIFF
--- a/mobile/bulingo/app/(tabs)/quizzes/quizCreationInfo.tsx
+++ b/mobile/bulingo/app/(tabs)/quizzes/quizCreationInfo.tsx
@@ -3,6 +3,7 @@ import { ScrollView, Keyboard, Pressable, StyleSheet, Text, TextInput, View, Tou
 import { router, useLocalSearchParams } from 'expo-router';
 import TokenManager from '@/app/TokenManager';
 import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
 
 const QuizCreationInfo = () => {
   const [question, setQuestion] = useState('');
@@ -29,7 +30,7 @@ const QuizCreationInfo = () => {
   const colorScheme = useColorScheme();
   const styles = getStyles(colorScheme);
 
-  const { initialQuestion, initialAnswers, initialCorrectAnswer, type, index, trigger} = useLocalSearchParams();
+  const { initialQuestion, initalQuestionImage, initialAnswers, initialCorrectAnswer, type, index, trigger} = useLocalSearchParams();
 
 
   const fetchVerticalOptions = async () => {
@@ -79,7 +80,9 @@ const QuizCreationInfo = () => {
       setAnswers(JSON.parse(Array.isArray(initialAnswers) ? initialAnswers[0] : initialAnswers));
       setCorrectAnswerIndex(Number(initialCorrectAnswer));
       setSelectedType(type instanceof Array ? type[0] : type);
+      setLocalImage(initalQuestionImage instanceof Array ? encodeURI(initalQuestionImage[0]) : encodeURI(initalQuestionImage));
     }
+    console.log(initalQuestionImage);
   }, [initialQuestion, initialAnswers, initialCorrectAnswer]);
 
   const handleGoBack = () => {
@@ -114,7 +117,7 @@ const QuizCreationInfo = () => {
   };
 
   const handleAddQuestion = () => {
-    router.navigate({ pathname: '/(tabs)/quizzes/quizCreationQuestionList', params: { question: question, answers: JSON.stringify(answers), correctAnswer: correctAnswerIndex, selectedType: selectedType, index: index, trigger: trigger} });
+    router.navigate({ pathname: '/(tabs)/quizzes/quizCreationQuestionList', params: { question: question, answers: JSON.stringify(answers), correctAnswer: correctAnswerIndex, selectedType: selectedType, index: index, trigger: trigger, questionImage: localImage} });
   };
 
   const handleTypeSelect = (type: string) => {
@@ -354,6 +357,7 @@ const QuizCreationInfo = () => {
               </Text>
             </TouchableOpacity>
           </View>
+
           <View style={styles.answerGridContainer}>
             {answerGrid.map((row, rowIndex) => (
               <View key={rowIndex} style={styles.answerRow}>

--- a/mobile/bulingo/app/(tabs)/quizzes/quizCreationQuestionList.tsx
+++ b/mobile/bulingo/app/(tabs)/quizzes/quizCreationQuestionList.tsx
@@ -8,6 +8,7 @@ import TokenManager from '@/app/TokenManager';
 type Question = {
   id: number;
   name: string;
+  image: string;
   correctAnswer: string;
   answers: string[]; 
   type: string;
@@ -93,7 +94,7 @@ const QuizCreationQuestionList = () => {
   };
 
   const handleUpdateQuestion = (index: number) => {
-    router.navigate({pathname: '/(tabs)/quizzes/quizCreationInfo', params: { "initialQuestion": questions[index].name , "initialAnswers": JSON.stringify(questions[index].answers), "initialCorrectAnswer": Number(questions[index].correctAnswer), "type": questions[index].type, "index": index, "trigger": key + 50}});
+    router.navigate({pathname: '/(tabs)/quizzes/quizCreationInfo', params: { "initialQuestion": questions[index].name, "initalQuestionImage": questions[index].image, "initialAnswers": JSON.stringify(questions[index].answers), "initialCorrectAnswer": Number(questions[index].correctAnswer), "type": questions[index].type, "index": index, "trigger": key + 50}});
   };
 
   const handleCreateQuiz = async () => {
@@ -115,21 +116,45 @@ const QuizCreationQuestionList = () => {
     formData.append('level', quizDetails['level']);
 
     console.log(formData);
+
+    
+
+    const questionsWithImages = questions.map((q, index) => {
+      if (q.image) {
+        const fileName = q.image.split('/').pop();
+        const fileType = fileName!.split('.').pop();
   
-    formData.append(
-      'questions',
-      JSON.stringify(
-        questions.map((q, index) => ({
+        formData.append(`question_image_${index + 1}`, {
+          uri: q.image,
+          name: fileName,
+          type: `image/${fileType}`,
+        });
+  
+        return {
           question_number: index + 1,
+          question_image: `question_image_${index + 1}`, // Image key for server to map
           question_text: q.name,
           choice1: q.answers[0],
           choice2: q.answers[1],
           choice3: q.answers[2],
           choice4: q.answers[3],
           correct_choice: Number(q.correctAnswer) + 1,
-        }))
-      )
-    );
+        };
+      } else {
+        return {
+          question_number: index + 1,
+          question_image: null, 
+          question_text: q.name,
+          choice1: q.answers[0],
+          choice2: q.answers[1],
+          choice3: q.answers[2],
+          choice4: q.answers[3],
+          correct_choice: Number(q.correctAnswer) + 1,
+        };
+      }
+    });
+  
+    formData.append('questions', JSON.stringify(questionsWithImages));;
 
 
     return formData;

--- a/mobile/bulingo/app/(tabs)/quizzes/quizCreationQuestionList.tsx
+++ b/mobile/bulingo/app/(tabs)/quizzes/quizCreationQuestionList.tsx
@@ -57,7 +57,7 @@ const QuizCreationQuestionList = () => {
   const colorScheme = useColorScheme();
   const styles = getStyles(colorScheme);
   
-  const { question, answers, correctAnswer, selectedType, index, trigger } = useLocalSearchParams();
+  const { question, questionImage, answers, correctAnswer, selectedType, index, trigger } = useLocalSearchParams();
   const parsedAnswers = Array.isArray(answers) ? answers.join(', ') : answers ? JSON.parse(answers) : [];
 
   const key = questions.length === 0 ? 0 : questions[questions.length - 1].id + 1;
@@ -68,6 +68,7 @@ const QuizCreationQuestionList = () => {
       const newQuestion = {
         id: index !== undefined ? questions[Number(index)].id : key,
         name: Array.isArray(question) ? question[0] : question,
+        image: Array.isArray(questionImage) ? questionImage[0] : questionImage ,
         correctAnswer: Array.isArray(correctAnswer) ? correctAnswer[0] : correctAnswer,
         answers: parsedAnswers,
         type: Array.isArray(selectedType) ? selectedType[0] : selectedType 


### PR DESCRIPTION
Fixes #892.

- This PR enables users to upload images for quiz questions.
- Deleting and changing image is possible. 
- The image is stored persistently until quiz is submitted. (Question list page keeps the images until quiz is submitted which allows users to edit images later on question update)
-  The utility is tested on an emulated android device. 

Example Image: 
<img width="383" alt="Screenshot 2024-12-16 at 02 54 12" src="https://github.com/user-attachments/assets/d9c3f1ec-29ab-4c56-ae26-56225352ae71" />
