### PR TITLE
Mobile: Remove Level from register & Fix Quiz Level on Search

### DIFF
--- a/mobile/bulingo/app/(tabs)/search.tsx
+++ b/mobile/bulingo/app/(tabs)/search.tsx
@@ -63,10 +63,9 @@ export default function Tab() {
             ...item,
             data: {
               ...item.data,
-              level: item.data.tags[0]
+              level: item.data.tags[0],
             }
           }));
-          console.log(transformed_data[0].data.tags)
         } else if (dataType == "user"){
           const username = TokenManager.getUsername();
           transformed_data = transformed_data.map((item:any) => ({

--- a/mobile/bulingo/app/components/quizCard.tsx
+++ b/mobile/bulingo/app/components/quizCard.tsx
@@ -30,6 +30,7 @@ export default function QuizCard(props: QuizCardProps){
   const [isTagEditVisible, setIsTagEditVisible] = useState(false);
   const [tags, setTags] = useState<string[]>([]);
   const [guestModalVisible, setGuestModalVisible] = useState(false);
+  const [level, setLevel] = useState(props.level);
 
   const colorScheme = useColorScheme();
   const styles = getStyles(colorScheme);
@@ -91,6 +92,7 @@ export default function QuizCard(props: QuizCardProps){
 
   useEffect(() => {
     fetchQuizTags();
+    console.log(props.level)
   },[])
 
   const fetchQuizTags = async () => {
@@ -105,6 +107,7 @@ export default function QuizCard(props: QuizCardProps){
       if(response.ok){
         const res = await response.json()
         setTags(res.quiz.tags);
+        setLevel(res.quiz.level);
         console.log(res);
       } else{
         console.warn(response.status)
@@ -151,7 +154,7 @@ export default function QuizCard(props: QuizCardProps){
         <View style={styles.quizBottom}>
           <View style={styles.quizBottomLeft}>
             <Text style={styles.quizAuthor}>by {props.author}</Text>
-            {props.level && <Text style={styles.quizLevel}>{props.level}</Text>}
+            {level && <Text style={styles.quizLevel}>{level}</Text>}
           </View>
           <TouchableOpacity style={styles.likeButton} onPress={() => handleLikePress(props.id)} testID='likeButton'>
             <Text style={styles.quizLikes}>

--- a/mobile/bulingo/app/register.tsx
+++ b/mobile/bulingo/app/register.tsx
@@ -12,7 +12,6 @@ const Register = () => {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [errors, setErrors] = useState({ email: '', password: '', confirmPassword: '', username: '' });
-  const [level, setLevel] = useState('A1');
   const [isFormValid, setIsFormValid] = useState(false);
   const [isTyping, setIsTyping] = useState(false);
 
@@ -184,24 +183,6 @@ const Register = () => {
       />
       <View style={{ minHeight: 18 }}>
         {errors.confirmPassword ? <Text style={styles.error}>{errors.confirmPassword}</Text> : null}
-      </View>
-
-
-      
-      <Text style={styles.label}>Level:</Text>
-      <View style={{borderRadius: 10, overflow: 'hidden', marginBottom: 16}}>
-      <Picker
-        selectedValue={level}
-        style={styles.picker}
-        onValueChange={(itemValue) => setLevel(itemValue)}
-      >
-        <Picker.Item label="A1" value="A1" />
-        <Picker.Item label="A2" value="A2" />
-        <Picker.Item label="B1" value="B1" />
-        <Picker.Item label="B2" value="B2" />
-        <Picker.Item label="C1" value="C1" />
-        <Picker.Item label="C2" value="C2" />
-      </Picker>
       </View>
 
       <TouchableOpacity 


### PR DESCRIPTION
Fixes #914.

This PR includes two main changes, which are:

1- The unused `level` input field has been removed from the register page
2- The quizCard and Search components have been altered to correctly display the quiz level in the search page.