### PR TITLE
feat(mobile): display quiz images on mobile

### DIFF
--- a/mobile/bulingo/app/(tabs)/quizzes/quizQuestion.tsx
+++ b/mobile/bulingo/app/(tabs)/quizzes/quizQuestion.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { TouchableOpacity, StyleSheet, Text, View } from 'react-native';
+import { TouchableOpacity, StyleSheet, Text, View, Image } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import TokenManager from '@/app/TokenManager';
 import { Dimensions, useColorScheme } from 'react-native';
@@ -10,6 +10,7 @@ const { width, height } = Dimensions.get('window');
 export type QuizQuestion = {
   question_number: number;
   question: string;
+  question_image: string | null;
   choices: string[];
   previous_answer: number | null;
 };
@@ -216,11 +217,38 @@ const QuizQuestion = () => {
         </View>
 
         <View style={[styles.questionWrapper, styles.elevation]}>
-          <View style={[styles.questionContainer, styles.questionAnswerElevation]}>
-            <PressableText style={styles.questionText} text={currentQuestion?.question || 'No question available'}/>
-            
-            {/* <Text style={styles.questionText}>{currentQuestion?.question || 'No question available'}</Text> */}
-          </View>
+            <View
+              style={[
+                styles.questionContainer,
+                styles.questionAnswerElevation,
+                !currentQuestion?.question_image && styles.centerContent, // Add centering style when no image
+              ]}
+            >
+              {/* Conditionally Render Image */}
+              {currentQuestion?.question_image ? (
+                <Image
+                  source={{ uri: currentQuestion.question_image }}
+                  style={styles.questionImage}
+                  resizeMode="contain"
+                />
+              ) : (
+                // If no image, ensure text centers vertically
+                <PressableText
+                  style={[styles.questionText, styles.centerText]} // Additional centering
+                  text={currentQuestion?.question || 'No question available'}
+                />
+              )}
+            </View>
+
+            {/* If image exists, show text below it */}
+            {currentQuestion?.question_image && (
+              <PressableText
+                style={[styles.questionText, styles.textBelowImage]}
+                text={currentQuestion?.question || 'No question available'}
+              />
+            )}
+
+
 
           <View style={styles.optionsContainer}>
             {currentQuestion?.choices.map((choice, index) => (
@@ -262,7 +290,7 @@ const QuizQuestion = () => {
           )}
         </View>
       </View>
-    </View>
+      </View>
   );
 };
 
@@ -290,6 +318,30 @@ export const getStyles = (colorScheme: any) => {
       justifyContent: 'space-between',
       alignItems: 'center',
     },
+    questionWrapper: {
+      backgroundColor: isDark ? '#1e1e2e' : 'white',
+      borderRadius: 10,
+      marginVertical: 10,
+      borderColor: isDark ? '#333' : 'transparent',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 10,
+    },
+    questionContainer: {
+      width: '100%',
+      minHeight: 200, // Set a minimum height to reserve space for image or text
+      alignItems: 'center',
+      justifyContent: 'flex-start', // Align items at the top by default
+      backgroundColor: isDark ? '#1e1e2e' : 'white',
+      marginBottom: 40,
+      borderRadius: 10,
+    },
+    questionImage: {
+      width: '100%',
+      height: 200,
+      marginBottom: 10,
+      borderRadius: 10,
+    },
     cancelQuizButton: {
       backgroundColor: isDark ? '#8b0000' : '#b22222',
       borderRadius: 10,
@@ -312,29 +364,13 @@ export const getStyles = (colorScheme: any) => {
       fontWeight: 'bold',
       color: 'white',
     },
-    questionWrapper: {
-      backgroundColor: isDark ? '#1e1e2e' : 'white',
-      borderRadius: 10,
-      justifyContent: "space-around",
-      padding: 20,
-      marginVertical: 10,
-      borderColor: isDark ? '#333' : 'transparent',
-    },
-    questionContainer: {
-      justifyContent: 'center',
-      backgroundColor: isDark ? '#1e1e2e' : 'white',
-      height: height * 0.25,
-      marginBottom: 40,
-      borderRadius: 10,
-      borderColor: isDark ? '#333' : '#222',
-      paddingHorizontal: 20,
-      alignItems: 'center',
-    },
+
     questionText: {
       fontSize: 28,
       fontWeight: 'bold',
       color: isDark ? 'white' : 'black',
       textAlign: 'center',
+      alignContent: 'center',
     },
     optionsContainer: {
       flexDirection: 'row',
@@ -409,6 +445,19 @@ export const getStyles = (colorScheme: any) => {
       textAlign: 'center',
       marginBottom: 16,
     },
+
+    centerContent: {
+      justifyContent: 'center',
+    },
+    centerText: {
+      textAlign: 'center', 
+    },
+    textBelowImage: {
+      textAlign: 'center',
+      marginTop: 10, 
+    },
+    
+    
   });
 };
 

--- a/mobile/bulingo/app/(tabs)/quizzes/quizReview.tsx
+++ b/mobile/bulingo/app/(tabs)/quizzes/quizReview.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { TouchableOpacity, StyleSheet, Text, View, ActivityIndicator } from 'react-native';
+import { TouchableOpacity, StyleSheet, Text, View, ActivityIndicator, Image } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import TokenManager from '@/app/TokenManager';
 import { Dimensions, useColorScheme } from 'react-native';
@@ -10,7 +10,8 @@ export type QuizQuestionReview = {
     question_number: number;       
     question: string;              
     choices: string[];             
-    correct_choice: number;        
+    correct_choice: number;
+    question_image: string | null;        
     previous_answer: number;
   };
   
@@ -112,11 +113,36 @@ useEffect(() => {
         </View>
 
         <View style={[styles.questionWrapper, styles.elevation]}>
-          <View style={[styles.questionContainer, styles.questionAnswerElevation]}>
-            <PressableText style={styles.questionText} text={currentQuestion?.question || 'No question available'}/>
-           
-            {/* <Text style={styles.questionText}>{currentQuestion?.question || 'No question available'}</Text> */}
-          </View>
+            <View
+              style={[
+                styles.questionContainer,
+                styles.questionAnswerElevation,
+                !currentQuestion?.question_image && styles.centerContent, // Add centering style when no image
+              ]}
+            >
+              {/* Conditionally Render Image */}
+              {currentQuestion?.question_image ? (
+                <Image
+                  source={{ uri: currentQuestion.question_image }}
+                  style={styles.questionImage}
+                  resizeMode="contain"
+                />
+              ) : (
+                // If no image, ensure text centers vertically
+                <PressableText
+                  style={[styles.questionText, styles.centerText]} // Additional centering
+                  text={currentQuestion?.question || 'No question available'}
+                />
+              )}
+            </View>
+
+            {/* If image exists, show text below it */}
+            {currentQuestion?.question_image && (
+              <PressableText
+                style={[styles.questionText, styles.textBelowImage]}
+                text={currentQuestion?.question || 'No question available'}
+              />
+            )}
 
           <View style={styles.optionsContainer}>
             {currentQuestion?.choices.map((choice, index) => {
@@ -180,6 +206,30 @@ export const getStyles = (colorScheme: any) => {
     navbarContainer: {
       flex: 1,
     },
+    questionWrapper: {
+      backgroundColor: isDark ? '#1e1e2e' : 'white',
+      borderRadius: 10,
+      marginVertical: 10,
+      borderColor: isDark ? '#333' : 'transparent',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 10,
+    },
+    questionContainer: {
+      width: '100%',
+      minHeight: 200, 
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+      backgroundColor: isDark ? '#1e1e2e' : 'white',
+      marginBottom: 40,
+      borderRadius: 10,
+    },
+    questionImage: {
+      width: '100%',
+      height: 200,
+      marginBottom: 10,
+      borderRadius: 10,
+    },
     page: {
       flex: 9,
       justifyContent: "space-around",
@@ -213,24 +263,6 @@ export const getStyles = (colorScheme: any) => {
       fontSize: 18,
       fontWeight: 'bold',
       color: 'white',
-    },
-    questionWrapper: {
-      backgroundColor: isDark ? '#1e1e2e' : 'white',
-      borderRadius: 10,
-      justifyContent: "space-around",
-      padding: 20,
-      marginVertical: 10,
-      borderColor: isDark ? '#333' : 'transparent',
-    },
-    questionContainer: {
-      justifyContent: 'center',
-      backgroundColor: isDark ? '#1e1e2e' : 'white',
-      height: height * 0.25,
-      marginBottom: 40,
-      borderRadius: 10,
-      borderColor: isDark ? '#333' : '#222',
-      paddingHorizontal: 20,
-      alignItems: 'center',
     },
     questionText: {
       fontSize: 28,
@@ -322,6 +354,16 @@ export const getStyles = (colorScheme: any) => {
       },
       wrongAnswer: {
         backgroundColor: 'lightcoral',
+      },
+      centerContent: {
+        justifyContent: 'center',
+      },
+      centerText: {
+        textAlign: 'center', 
+      },
+      textBelowImage: {
+        textAlign: 'center',
+        marginTop: 10, 
       },
       
   });


### PR DESCRIPTION
Fixes #917.

- The quiz image is now enabled on both the quiz question page and the quiz review page.

- If a quiz image is available, it is displayed alongside the quiz question text.

- If no quiz image is found, only the quiz question text is displayed.

Here are example images: 
<img width="383" alt="Screenshot 2024-12-16 at 04 10 32" src="https://github.com/user-attachments/assets/00c6b118-f816-4187-9d90-5a2ba59572e2" />
<img width="383" alt="Screenshot 2024-12-16 at 04 10 51" src="https://github.com/user-attachments/assets/4122aa89-6fe0-4a46-8821-c25e89792c48" />
<img width="383" alt="Screenshot 2024-12-16 at 04 10 38" src="https://github.com/user-attachments/assets/348c9319-42ea-4d89-9343-c27ea9457c72" />
<img width="383" alt="Screenshot 2024-12-16 at 04 10 54" src="https://github.com/user-attachments/assets/d6e77ff4-9ffc-465a-8c0c-1b6ee94f1378" />


