### PR TITLE
Add onPress to pressable text

### DIFF
--- a/mobile/bulingo/app/pressableText.tsx
+++ b/mobile/bulingo/app/pressableText.tsx
@@ -6,6 +6,7 @@ type PressableTextProps = {
   text: string,
   style?: StyleProp<TextStyle>
   containerStyle?: StyleProp<ViewStyle>
+  onPress?: (word: string) => void
 };
 
 export default function PressableText(props: PressableTextProps){
@@ -35,6 +36,7 @@ export default function PressableText(props: PressableTextProps){
         <Pressable
           key={index}
           onLongPress={() => handleLongPress(word)}
+          onPress={() => {props.onPress && props.onPress(word)}}
           // style={}
         >
             <Text style={props.style}>


### PR DESCRIPTION
Fixes #928.

Extremely small fix that just adds an onPress optional prop to the pressable text component.