### PR TITLE
Profile Page Fixes for PostCard and CommentCard pages

### DIFF
--- a/mobile/bulingo/app/(tabs)/profile/bookmarkedPostsAndComments.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/bookmarkedPostsAndComments.tsx
@@ -1,13 +1,18 @@
 import React, { useState, useEffect } from 'react';
 import {Text, StyleSheet, FlatList, View, TouchableWithoutFeedback, ActivityIndicator } from 'react-native';
 import TokenManager from '@/app/TokenManager';
+import CommentCard from '@/app/components/commentcard';
+import PostCard from '@/app/components/postcard';
+import { router } from 'expo-router';
+import { likePost, bookmarkPost, unlikePost, unbookmarkPost, likeComment, unlikeComment } from '../../api/forum'; // Import the functions from forum.tsx
 
 export default function Followers() {
   const [isLoading, setIsLoading] = useState(true);
-  const [bookmarkedPostsAndComments, setBoormarkedPostAndComments] = useState<any[]>([])
+  const [bookmarkedComments, setBookmarkedComments] = useState<any[]>([])
+  const [bookmarkedPosts, setBookmarkedPosts] = useState<any[]>([])
 
   useEffect(() => {
-    const fetchFollowers = async () => {
+    const fetchBookmarkedPostAndComments = async () => {
       const username = TokenManager.getUsername();
       if(username === undefined){
         console.error('username is undefined!');
@@ -27,7 +32,24 @@ export default function Followers() {
 
         if (response.ok){
           const result = await response.json();
-          setBoormarkedPostAndComments(result);
+          setBookmarkedPosts(result);
+          try {
+            const response2 = await TokenManager.authenticatedFetch("comments/bookmarked/", {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify(params),
+            });
+    
+            if (response.ok){
+              const result2 = await response2.json();
+              setBookmarkedComments(result2)
+            }
+          }
+          catch (error){
+            console.error(error)
+          }
         } else {
           console.log(response.status)
         };
@@ -36,7 +58,7 @@ export default function Followers() {
       }
       setIsLoading(false);
     };
-    fetchFollowers();
+    fetchBookmarkedPostAndComments();
   }, []);
 
   if(isLoading){
@@ -49,16 +71,141 @@ export default function Followers() {
     );
   };
 
+  const handlePostPress = (id: number) => {
+    router.navigate({pathname: '/(tabs)/forums/forumPostPage', params: {
+       "id": id,
+      }});
+  };
+
+  const handleLikePress = async (postId: number): Promise<void> => { 
+    bookmarkedPosts.map(async item => {
+      if (item.id === postId) {
+        if(item.is_liked){
+          try {
+            const response = await unlikePost(postId);
+            if (response) {
+              setBookmarkedPosts(bookmarkedPosts.map(item => {
+                return (item.comments && item.id === postId) ? {...item, is_liked: response.is_liked, like_count: response.like_count} : item
+              }))
+            }
+          } catch (error) {
+            console.error('Failed to unlike post:', error);
+          }
+        }
+        else{
+          try {
+            const response = await likePost(postId);
+            if (response) {
+              setBookmarkedPosts(bookmarkedPosts.map(item => {
+                return (item.comments && item.id === postId) ? {...item, is_liked: response.is_liked, like_count: response.like_count} : item
+              }))
+            }
+          } catch (error) {
+            console.error('Failed to like post:', error);
+          }
+        }
+
+      }
+    })
+    
+
+
+  };
+
+  const handleBookmarkPress = async (postId: number): Promise<void> => {
+    bookmarkedPosts.map(async item => {
+      if (item.id === postId) {
+        if(item.is_bookmarked){
+          try {
+            const response = await unbookmarkPost(postId);
+            if (response) {
+              setBookmarkedPosts(bookmarkedPosts.map(item => {
+                return (item.comments && item.id === postId) ? {...item, is_bookmarked: response.is_bookmarked} : item
+              }))
+            }
+          } catch (error) {
+            console.error('Failed to unbookmark post:', error);
+          }
+        }
+        else{
+          try {
+            const response = await bookmarkPost(postId);
+            if (response) {
+              setBookmarkedPosts(bookmarkedPosts.map(item => {
+                return (item.comments && item.id === postId) ? {...item, is_bookmarked: response.is_bookmarked} : item
+              }))
+            }
+          } catch (error) {
+            console.error('Failed to bookmark post:', error);
+          }
+        }
+      }
+    })
+    
+  };
+
+  const handleLikeComment = async (commentId: number) => {
+    bookmarkedComments.map(async item => {
+      if (!item.comments && item.id === commentId) {
+        if (item.is_liked) {
+          try {
+            const response = await unlikeComment(commentId);
+            if (response) {
+              setBookmarkedComments(bookmarkedComments.map(item => { 
+                return (!item.comments && item.id === commentId) ? {...item, is_liked: !item.is_liked, like_count: response.like_count} : item;
+              }))
+            }
+          } catch (error) {
+            console.error('Failed to unlike comment:', error);
+          }
+        } else {
+          try {
+            const response = await likeComment(commentId);
+            if (response) {
+              setBookmarkedComments(bookmarkedComments.map(item => { 
+                return (!item.comments && item.id === commentId) ? {...item, is_liked: !item.is_liked, like_count: response.like_count} : item;
+              }))
+            }
+          } catch (error) {
+            console.error('Failed to like comment:', error);
+          }
+        }
+      }
+    });
+  };
+
   return (
     <FlatList
-      data={bookmarkedPostsAndComments}
-      keyExtractor={(item) => item.name}  // Placeholder, change with post/comment card
+      data={bookmarkedComments.concat(bookmarkedPosts)}
+      keyExtractor={item => `${item.id}${item.comments ? 'yes' : 'no'}`}
       renderItem={({item}) => {  // Placeholder, replace with post/comment card
-        return (
-          <View style={{height: 100, borderWidth: 3, borderColor: 'black', borderRadius: 15, justifyContent: 'center', alignItems: 'center', marginHorizontal: 15, marginVertical: 5,}}>
-            <Text>Placeholder Item: {item.name}</Text>
-          </View>
-        );
+        if(item.comments){
+          // /// Post
+          console.log("Post", item)
+          return (
+            <PostCard title={item.title} id={item.id} author={TokenManager.getUsername() || ''} likes={item.like_count} 
+              liked={item.is_liked} tags={item.tags} feedOrPost='feed' isBookmarked={item.is_bookmarked} 
+              onUpvote={() => handleLikePress(item.id)}
+              onBookmark={() => handleBookmarkPress(item.id)}
+              onPress={() => handlePostPress(item.id)}
+            />
+          );
+        }
+        else{
+          // Comment
+          console.log("Comment", item)
+          return (
+            <CommentCard
+            id={item.id}
+            username={item.author}
+            onUpvote={handleLikeComment}
+            comment={item.body}
+            isBookmarked={item.is_bookmarked}
+            liked={item.is_liked}
+            likes={item.like_count}
+          />
+          );
+        }
       }}
       ListHeaderComponent={
         <View style={styles.headerContainer}>

--- a/mobile/bulingo/app/(tabs)/profile/bookmarkedPostsAndComments.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/bookmarkedPostsAndComments.tsx
@@ -181,7 +181,6 @@ export default function Followers() {
       renderItem={({item}) => {  // Placeholder, replace with post/comment card
         if(item.comments){
           // /// Post
-          console.log("Post", item)
           return (
             <PostCard title={item.title} id={item.id} author={TokenManager.getUsername() || ''} likes={item.like_count} 
               liked={item.is_liked} tags={item.tags} feedOrPost='feed' isBookmarked={item.is_bookmarked} 
@@ -193,7 +192,6 @@ export default function Followers() {
         }
         else{
           // Comment
-          console.log("Comment", item)
           return (
             <CommentCard
             id={item.id}

--- a/mobile/bulingo/app/(tabs)/profile/bookmarkedQuizzes.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/bookmarkedQuizzes.tsx
@@ -7,7 +7,7 @@ import TokenManager from '@/app/TokenManager';
 
 export default function Followers() {
   const [isLoading, setIsLoading] = useState(true);
-  const [bookmarkedQuizzes, setBoormarkedQuizzes] = useState<QuizInfo[]>([])
+  const [bookmarkedQuizzes, setBookmarkedQuizzes] = useState<QuizInfo[]>([])
 
   useEffect(() => {
     const fetchFollowers = async () => {
@@ -22,6 +22,8 @@ export default function Followers() {
 
         if (response.ok){
           const result = await response.json()
+          console.log(result)
+          setBookmarkedQuizzes(result);
         } else {
           console.log(response.status)
         };
@@ -49,7 +51,7 @@ export default function Followers() {
       renderItem={({item}) => {  // Placeholder, replace with quiz card
         return (
           <QuizCard id={item.id} author={item.author.username} title={item.title} level={item.level} 
-              description={item.description} liked={item.is_liked} likes={item.like_count}/>
+              description={item.description} liked={item.is_liked} likes={item.like_count} bookmarked={item.is_bookmarked}/>
         );
       }}
       ListHeaderComponent={

--- a/mobile/bulingo/app/(tabs)/profile/index.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/index.tsx
@@ -102,8 +102,6 @@ export default function Profile() {
           const profileResponse = await profileRequest.json();
           if (profileRequest.ok){
             updatedUserInfo = profileResponse
-            console.log("HERE!")
-            console.log(profileResponse);
           } else {
             console.log(profileRequest.status)
           };
@@ -284,7 +282,6 @@ export default function Profile() {
   };
 
   const handleLikeComment = async (commentId: number) => {
-    console.log(userInfo.comments);
     userInfo.comments.map(async comment => {
       if (comment.id === commentId) {
         if (comment.is_liked) {

--- a/mobile/bulingo/app/(tabs)/profile/likedPostsAndComments.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/likedPostsAndComments.tsx
@@ -15,7 +15,7 @@ export default function Followers() {
   ])
 
   useEffect(() => {
-    const ENDPOINT_URL = "http://64.226.76.231:8000/likedpostandcomments";  // Placeholder
+    const ENDPOINT_URL = "http://161.35.208.249:800000/likedpostandcomments";  // Placeholder
     const fetchFollowers = async () => {
       const params = {
         // TODO

--- a/mobile/bulingo/app/(tabs)/profile/likedPostsAndComments.tsx
+++ b/mobile/bulingo/app/(tabs)/profile/likedPostsAndComments.tsx
@@ -1,36 +1,50 @@
 import React, { useState, useEffect } from 'react';
 import {Text, StyleSheet, FlatList, View, TouchableWithoutFeedback, ActivityIndicator } from 'react-native';
-
-type LikedPostAndCommentsInfoPlaceholder = {  // Placeholder, remove when Quiz Card is ready.
-  name: string,
-};
+import TokenManager from '@/app/TokenManager';
+import { router } from 'expo-router';
+import { likePost, bookmarkPost, unlikePost, unbookmarkPost, likeComment, unlikeComment } from '../../api/forum'; // Import the functions from forum.tsx
+import PostCard from '@/app/components/postcard';
+import CommentCard from '@/app/components/commentcard';
 
 export default function Followers() {
   const [isLoading, setIsLoading] = useState(true);
-  const [likedPostAndComments, setLikedPostAndComments] = useState<LikedPostAndCommentsInfoPlaceholder[]>([
-    {name: 'Post 1'},  // Placeholder
-    {name: 'Comment 1'},  // Placeholder
-    {name: 'Comment 2'},  // Placeholder
-    {name: 'Post 2'},  // Placeholder
-  ])
+  const [likedPosts, setLikedPosts] = useState<any[]>([]);
+  const [likedComments, setLikedComments] = useState<any[]>([])
+
 
   useEffect(() => {
-    const ENDPOINT_URL = "http://161.35.208.249:800000/likedpostandcomments";  // Placeholder
-    const fetchFollowers = async () => {
-      const params = {
-        // TODO
-       };
+    const fetchLikedPostsAndComments = async () => {
+      const url = "post/liked/"
       try {
-        const response = await fetch(ENDPOINT_URL, {
-          method: 'POST',
+        const response = await TokenManager.authenticatedFetch(url, {
+          method: 'GET',
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify(params),
         });
 
         if (response.ok){
-          setLikedPostAndComments(await response.json());
+          const result = await response.json()
+          setLikedPosts(result.liked_posts);
+        } else {
+          console.log(response.status)
+        };
+      } catch (error) {
+        console.error(error);
+      }
+
+      const url2 = "comments/liked/"
+      try {
+        const response = await TokenManager.authenticatedFetch(url2, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        if (response.ok){
+          const result = await response.json()
+          setLikedComments(result.liked_comments);
         } else {
           console.log(response.status)
         };
@@ -39,7 +53,7 @@ export default function Followers() {
       }
       setIsLoading(false);
     };
-    fetchFollowers();
+    fetchLikedPostsAndComments();
   }, []);
 
   if(isLoading){
@@ -52,16 +66,139 @@ export default function Followers() {
     );
   };
 
+
+  const handlePostPress = (id: number) => {
+    router.navigate({pathname: '/(tabs)/forums/forumPostPage', params: {
+       "id": id,
+      }});
+  };
+
+  const handleLikePress = async (postId: number): Promise<void> => { 
+    likedPosts.map(async item => {
+      if (item.id === postId) {
+        if(item.is_liked){
+          try {
+            const response = await unlikePost(postId);
+            if (response) {
+              setLikedPosts(likedPosts.map(item => {
+                return (item.id === postId) ? {...item, is_liked: response.is_liked, like_count: response.like_count} : item
+              }))
+            }
+          } catch (error) {
+            console.error('Failed to unlike post:', error);
+          }
+        }
+        else{
+          try {
+            const response = await likePost(postId);
+            if (response) {
+              setLikedPosts(likedPosts.map(item => {
+                return (item.id === postId) ? {...item, is_liked: response.is_liked, like_count: response.like_count} : item
+              }))
+            }
+          } catch (error) {
+            console.error('Failed to like post:', error);
+          }
+        }
+
+      }
+    })
+    
+
+
+  };
+
+  const handleBookmarkPress = async (postId: number): Promise<void> => {
+    likedPosts.map(async item => {
+      if (item.id === postId) {
+        if(item.is_bookmarked){
+          try {
+            const response = await unbookmarkPost(postId);
+            if (response) {
+              setLikedPosts(likedPosts.map(item => {
+                return (item.id === postId) ? {...item, is_bookmarked: response.is_bookmarked} : item
+              }))
+            }
+          } catch (error) {
+            console.error('Failed to unbookmark post:', error);
+          }
+        }
+        else{
+          try {
+            const response = await bookmarkPost(postId);
+            if (response) {
+              setLikedPosts(likedPosts.map(item => {
+                return (item.id === postId) ? {...item, is_bookmarked: response.is_bookmarked} : item
+              }))
+            }
+          } catch (error) {
+            console.error('Failed to bookmark post:', error);
+          }
+        }
+      }
+    })
+    
+  };
+
+  const handleLikeComment = async (commentId: number) => {
+    likedComments.map(async item => {
+      if (item.id === commentId) {
+        if (item.is_liked) {
+          try {
+            const response = await unlikeComment(commentId);
+            if (response) {
+              setLikedComments(likedComments.map(item => { 
+                return (item.id === commentId) ? {...item, is_liked: !item.is_liked, like_count: response.like_count} : item;
+              }))
+            }
+          } catch (error) {
+            console.error('Failed to unlike comment:', error);
+          }
+        } else {
+          try {
+            const response = await likeComment(commentId);
+            if (response) {
+              setLikedComments(likedComments.map(item => { 
+                return (item.id === commentId) ? {...item, is_liked: !item.is_liked, like_count: response.like_count} : item;
+              }))
+            }
+          } catch (error) {
+            console.error('Failed to like comment:', error);
+          }
+        }
+      }
+    });
+  };
+
+
   return (
     <FlatList
-      data={likedPostAndComments}
-      keyExtractor={(item) => item.name}  // Placeholder, change with quiz card
+      data={likedPosts.concat(likedComments)}
+      keyExtractor={(item) => `${item.id}${item.tags ? 'yes' : 'no'}`}  // Placeholder, change with quiz card
       renderItem={({item}) => {  // Placeholder, replace with quiz card
-        return (
-          <View style={{height: 100, borderWidth: 3, borderColor: 'black', borderRadius: 15, justifyContent: 'center', alignItems: 'center', marginHorizontal: 15, marginVertical: 5,}}>
-            <Text>Placeholder Item: {item.name}</Text>
-          </View>
-        );
+        if(item.tags){
+          return (
+            <PostCard title={item.title} id={item.id} author={TokenManager.getUsername() || ''} likes={item.like_count} 
+              liked={item.is_liked} tags={item.tags} feedOrPost='feed' isBookmarked={item.is_bookmarked} 
+              onUpvote={() => handleLikePress(item.id)}
+              onBookmark={() => handleBookmarkPress(item.id)}
+              onPress={() => handlePostPress(item.id)}
+            />
+          );
+        }
+        else{
+          return (
+            <CommentCard
+            id={item.id}
+            username={item.author}
+            onUpvote={handleLikeComment}
+            comment={item.body}
+            isBookmarked={item.is_bookmarked}
+            liked={item.is_liked}
+            likes={item.like_count}
+          />
+          );
+        }
       }}
       ListHeaderComponent={
         <View style={styles.headerContainer}>

--- a/mobile/bulingo/app/TokenManager.ts
+++ b/mobile/bulingo/app/TokenManager.ts
@@ -78,8 +78,6 @@ class TokenManager {
     options: RequestInit = {}
   ): Promise<Response> {
     let accessToken = await this.getAccessToken();
-    console.log("accessToken")
-    console.log(accessToken)
     if (!accessToken) {
       throw new Error("No access token found. User needs to log in again.");
     }

--- a/mobile/bulingo/app/_layout.tsx
+++ b/mobile/bulingo/app/_layout.tsx
@@ -3,7 +3,6 @@ import { Stack } from 'expo-router';
 
 export default function Layout() {
 
-    console.log("Layout run")
   return (
     <Stack
       screenOptions={{


### PR DESCRIPTION
Fixes #921.
This PR includes changes to a variety of pages in the profile. The complete list of changes can be found below.

* The placeholders in the Profile tab have been replaced with 'card' components.
* The bookmarked and liked posts/comments pages have been connected to the backend
* The postcard and commentcard components used in these pages have been made operational, with functional like and bookmark buttons.
